### PR TITLE
feat(gui): add desktop client and Windows/macOS previews

### DIFF
--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -1,0 +1,154 @@
+name: GUI desktop release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Optional gui-v* tag to publish as a prerelease"
+        required: false
+        type: string
+  push:
+    tags:
+      - "gui-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            gui/pyproject.toml
+            gui/packaging/constraints.txt
+            gui/packaging/requirements-build.txt
+      - name: Install test dependencies
+        run: >-
+          python -m pip install
+          --constraint gui/packaging/constraints.txt
+          --requirement gui/packaging/requirements-build.txt
+          --editable "./gui[dev]"
+      - name: Check package
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          python -m pip check
+          python -m ruff check gui
+          python -m pytest -q gui/tests
+          python -m build --wheel gui
+          python -m xrayebator_gui --self-test
+
+  build:
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-2025
+            artifact_name: Xrayebator-Windows-x64
+            artifact_file: Xrayebator-Windows-x64.exe
+            platform: windows
+          - runner: macos-15-intel
+            artifact_name: Xrayebator-macOS-Intel
+            artifact_file: Xrayebator-macOS-Intel.dmg
+            platform: macos
+          - runner: macos-15
+            artifact_name: Xrayebator-macOS-Apple-Silicon
+            artifact_file: Xrayebator-macOS-Apple-Silicon.dmg
+            platform: macos
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            gui/pyproject.toml
+            gui/packaging/constraints.txt
+            gui/packaging/requirements-build.txt
+      - name: Install build dependencies
+        run: >-
+          python -m pip install
+          --constraint gui/packaging/constraints.txt
+          --requirement gui/packaging/requirements-build.txt
+          ./gui
+      - name: Bundle verified Xray core
+        run: python gui/packaging/fetch_xray.py
+      - name: Build native application
+        run: python gui/packaging/build.py
+      - name: Smoke-test Windows executable
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $env:QT_QPA_PLATFORM = "offscreen"
+          & "gui/dist/Xrayebator.exe" --self-test
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Package Windows executable
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force gui/artifacts | Out-Null
+          Copy-Item gui/dist/Xrayebator.exe "gui/artifacts/${{ matrix.artifact_file }}"
+          python gui/packaging/checksum.py "gui/artifacts/${{ matrix.artifact_file }}"
+      - name: Smoke-test macOS application
+        if: matrix.platform == 'macos'
+        run: |
+          QT_QPA_PLATFORM=offscreen \
+            gui/dist/Xrayebator.app/Contents/MacOS/Xrayebator --self-test
+      - name: Package macOS disk image
+        if: matrix.platform == 'macos'
+        run: |
+          mkdir -p gui/artifacts/dmg-root
+          cp -R gui/dist/Xrayebator.app gui/artifacts/dmg-root/
+          ln -s /Applications gui/artifacts/dmg-root/Applications
+          hdiutil create \
+            -volname Xrayebator \
+            -srcfolder gui/artifacts/dmg-root \
+            -ov \
+            -format UDZO \
+            "gui/artifacts/${{ matrix.artifact_file }}"
+          python gui/packaging/checksum.py "gui/artifacts/${{ matrix.artifact_file }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: |
+            gui/artifacts/${{ matrix.artifact_file }}
+            gui/artifacts/${{ matrix.artifact_file }}.sha256
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/gui-v') || inputs.release_tag != ''
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Publish GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            tag="${REQUESTED_TAG}"
+          fi
+          [[ "${tag}" == gui-v* ]] || {
+            echo "Release tag must start with gui-v" >&2
+            exit 2
+          }
+          gh release create "${tag}" artifacts/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --target "${GITHUB_SHA}" \
+            --title "Xrayebator GUI ${tag#gui-v}" \
+            --generate-notes \
+            --prerelease

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -45,7 +45,6 @@ jobs:
           python -m ruff check --config gui/pyproject.toml gui
           python -m pytest -q gui/tests
           python -m build --wheel gui
-          python -m xrayebator_gui --self-test
 
   build:
     needs: test

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -1,6 +1,10 @@
 name: GUI desktop release
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/gui-release.yml"
+      - "gui/**"
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/gui-release.yml
+++ b/.github/workflows/gui-release.yml
@@ -42,7 +42,7 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           python -m pip check
-          python -m ruff check gui
+          python -m ruff check --config gui/pyproject.toml gui
           python -m pytest -q gui/tests
           python -m build --wheel gui
           python -m xrayebator_gui --self-test

--- a/gui/.gitignore
+++ b/gui/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/
+.venv/
+build/
+dist/

--- a/gui/.gitignore
+++ b/gui/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 .venv/
 build/
 dist/
+artifacts/
+vendor/*.zip

--- a/gui/DEVELOPMENT_PLAN.md
+++ b/gui/DEVELOPMENT_PLAN.md
@@ -16,6 +16,17 @@ The GUI must run as an ordinary desktop user. Operations that require network
 administration rights belong to a narrow local service with an authenticated,
 typed IPC API. The service must not expose arbitrary command execution.
 
+## Current implementation status
+
+- Linux desktop MVP: implemented and unit/integration tested.
+- One-click VPS deployment for root and sudo users: implemented.
+- Native Xray TUN, DNS redirection, nftables kill switch, helper recovery:
+  implemented; live helper install and check-only firewall self-test passed.
+- Full/Smart RU routing profiles, verified route/profile rollback, RTT probes,
+  and tray controls: implemented.
+- Windows/macOS TUN config fixtures: implemented; native privileged services,
+  installers, signing, and live platform tests remain.
+
 ## Invariants
 
 1. The GUI never stores SSH passwords in JSON or logs.

--- a/gui/DEVELOPMENT_PLAN.md
+++ b/gui/DEVELOPMENT_PLAN.md
@@ -24,8 +24,9 @@ typed IPC API. The service must not expose arbitrary command execution.
   implemented; live helper install and check-only firewall self-test passed.
 - Full/Smart RU routing profiles, verified route/profile rollback, RTT probes,
   and tray controls: implemented.
+- Windows/macOS system-proxy preview bundles: implemented in native CI runners.
 - Windows/macOS TUN config fixtures: implemented; native privileged services,
-  installers, signing, and live platform tests remain.
+  signing/notarization, and live platform tests remain.
 
 ## Invariants
 

--- a/gui/DEVELOPMENT_PLAN.md
+++ b/gui/DEVELOPMENT_PLAN.md
@@ -1,0 +1,105 @@
+# Xrayebator GUI Development Plan
+
+## Product target
+
+Xrayebator GUI is a cross-platform desktop client for a self-hosted Xrayebator
+server. It combines:
+
+- one-click VPS deployment over SSH;
+- subscription and route management similar to HAPP/INCY;
+- a primary Xray-native TUN connection mode;
+- an optional system-proxy mode;
+- safe connect, disconnect, route switching, tray operation, DNS protection,
+  and kill-switch behavior.
+
+The GUI must run as an ordinary desktop user. Operations that require network
+administration rights belong to a narrow local service with an authenticated,
+typed IPC API. The service must not expose arbitrary command execution.
+
+## Invariants
+
+1. The GUI never stores SSH passwords in JSON or logs.
+2. A route switch either reaches a verified connection or restores the last
+   known-good route.
+3. TUN routes never capture the Xray server's own outbound traffic.
+4. DNS follows the selected routing profile and does not silently fall back to
+   the physical interface while the kill switch is active.
+5. Closing the window keeps the connection alive in the tray; explicit Quit
+   performs the configured shutdown behavior.
+6. Server-side deployment remains compatible with the repository's
+   `install.sh` and `xrayebator quickstart --email ...` contract.
+
+## Delivery phases
+
+### Phase 1 — Runnable desktop skeleton
+
+- Package installs and starts on a clean Python environment.
+- Main window, tray, server list, route selector, log panel, and connection
+  status are present.
+- Existing SSH deployment, subscription parser, server store, Xray process,
+  and system-proxy modules are connected through explicit application
+  controllers.
+- Connection lifecycle uses a tested state machine instead of button-local
+  booleans.
+
+**Done when:** the application launches, can deploy or load a server, fetch its
+subscription, connect in system-proxy mode, switch a route with rollback, and
+disconnect cleanly.
+
+### Phase 2 — Xray-native TUN vertical slice
+
+- Pin a known-good Xray version that contains the native TUN implementation.
+- Generate TUN inbound configuration with `autoSystemRoutingTable` and
+  `autoOutboundsInterface`.
+- Implement platform capability checks and actionable errors.
+- Keep system-proxy mode as an independent fallback.
+
+**Done when:** Linux, Windows, and macOS configuration fixtures validate, and a
+Linux integration run sends TCP, UDP, and DNS traffic through TUN without a
+route loop.
+
+### Phase 3 — Privileged network service and safe switching
+
+- Add a minimal privileged local service and authenticated IPC.
+- Move TUN/core lifecycle, OS routes, DNS, and firewall operations into it.
+- Implement the connection state machine:
+  `disconnected → preparing → connecting → verifying → connected`, plus
+  `switching`, `disconnecting`, `recovering`, and `error`.
+- During route switching, keep the traffic guard active, verify the candidate,
+  and roll back to the last known-good route on failure.
+
+**Done when:** killing the GUI does not leak or corrupt routes, killing Xray
+  triggers recovery or a closed kill-switch state, and failed switches restore
+  the previous route.
+
+### Phase 4 — One-click product flow and routing profiles
+
+- Make “Deploy and connect” the first-run path.
+- Add full-tunnel and smart `proxy/direct/block` profiles.
+- Split remote and direct DNS resolution.
+- Add subscription refresh, latency probes, manual route selection, and
+  last-known-good persistence.
+- Expose connect, disconnect, server, route, and mode in the tray.
+
+**Done when:** a user can go from clean VPS credentials to a verified TUN
+  connection without opening a terminal.
+
+### Phase 5 — Hardening, packaging, and release
+
+- Signed/pinned core downloads and reproducible package inputs.
+- Windows service + Wintun packaging, macOS launch daemon/signing hooks, and
+  Linux systemd/polkit packages.
+- Suspend/resume, network-change recovery, update safety, diagnostics export,
+  and uninstall cleanup.
+- Unit, integration, privilege-boundary, route-leak, DNS-leak, and disposable
+  VPS smoke tests.
+
+**Done when:** installers for all three desktop platforms pass the release
+  checklist and uninstall restores network state.
+
+## Deferred until after the first stable release
+
+- Per-application split tunneling on every platform.
+- Automatic load balancing across multiple routes.
+- Mobile applications.
+- Supporting non-Xray protocols unrelated to Xrayebator subscriptions.

--- a/gui/README.md
+++ b/gui/README.md
@@ -23,6 +23,18 @@ The application stores server metadata in the platform user-data directory.
 SSH passwords are stored through the operating system keyring rather than in
 `servers.json`.
 
+## Linux TUN helper
+
+When the helper is absent, the main window shows **Install TUN helper**.
+The action invokes `pkexec`, installs a root-owned copy of the narrow helper
+API and the pinned Xray core, then starts
+`xrayebator-gui-helper.service`. The service socket authorizes only the UID
+that performed the desktop installation.
+
+The installer supports `x86_64` and `aarch64`, verifies the Xray archive
+against an embedded SHA-256, and does not execute Xray from the user's
+workspace. It requires `python3`, `curl`, `unzip`, `nft`, and `systemd`.
+
 ## Current flow
 
 1. Add VPS credentials.

--- a/gui/README.md
+++ b/gui/README.md
@@ -64,8 +64,8 @@ rather than cross-compiling:
 
 Every bundle contains the pinned Xray archive after checking its upstream
 SHA-256 file. A matching `.sha256` sidecar is published with every artifact.
-Manual workflow runs produce CI artifacts; pushing a `gui-v*` tag additionally
-creates a GitHub prerelease.
+GUI pull requests and manual workflow runs produce CI artifacts; pushing a
+`gui-v*` tag additionally creates a GitHub prerelease.
 
 These preview binaries are not yet signed or notarized. Windows SmartScreen
 and macOS Gatekeeper can therefore display an unverified-publisher warning.

--- a/gui/README.md
+++ b/gui/README.md
@@ -3,10 +3,11 @@
 Desktop client for deploying Xrayebator to a VPS and connecting through an
 Xray VLESS Reality subscription.
 
-The current development build supports the system-proxy connection path.
-Xray-native TUN is the primary target and is tracked in
-[`DEVELOPMENT_PLAN.md`](DEVELOPMENT_PLAN.md); it is not presented as complete
-until route, DNS, privilege, and leak-safety checks pass.
+The current development build supports the system-proxy connection path and
+contains the Linux Xray-native TUN helper. TUN is enabled in the UI only when
+the privileged helper socket is installed and reachable. Packaging and live
+route/DNS leak verification are still tracked in
+[`DEVELOPMENT_PLAN.md`](DEVELOPMENT_PLAN.md).
 
 ## Development
 
@@ -30,5 +31,6 @@ SSH passwords are stored through the operating system keyring rather than in
 4. Save the returned subscription URL.
 5. Load subscription routes and connect through local Xray.
 
-Do not use the development build as a leak-proof VPN yet. TUN, DNS guarding,
-kill switch, and privileged service isolation are required before that claim.
+Do not use the development build as a leak-proof VPN yet. The helper contains
+DNS guarding and a fail-closed nftables kill switch, but packaging and live
+integration checks are required before that claim.

--- a/gui/README.md
+++ b/gui/README.md
@@ -41,7 +41,8 @@ workspace. It requires `python3`, `curl`, `unzip`, `nft`, and `systemd`.
 2. Deploy `install.sh` and the local `xrayebator` script over SSH.
 3. Run `xrayebator quickstart --email ...` remotely.
 4. Save the returned subscription URL.
-5. Load subscription routes and connect through local Xray.
+5. Load routes, select the preferred Vision transport, and connect
+   automatically through native TUN (or the system-proxy fallback).
 
 After setup, connect/disconnect, server, transport route, and routing profile
 are available from the tray menu. Subscription bearer URLs and VLESS links are

--- a/gui/README.md
+++ b/gui/README.md
@@ -43,6 +43,11 @@ workspace. It requires `python3`, `curl`, `unzip`, `nft`, and `systemd`.
 4. Save the returned subscription URL.
 5. Load subscription routes and connect through local Xray.
 
+After setup, connect/disconnect, server, transport route, and routing profile
+are available from the tray menu. Subscription bearer URLs and VLESS links are
+redacted from UI logs; local metadata and runtime configs are written with
+owner-only permissions.
+
 Do not use the development build as a leak-proof VPN yet. The helper contains
 DNS guarding and a fail-closed nftables kill switch, but packaging and live
 integration checks are required before that claim.

--- a/gui/README.md
+++ b/gui/README.md
@@ -3,11 +3,11 @@
 Desktop client for deploying Xrayebator to a VPS and connecting through an
 Xray VLESS Reality subscription.
 
-The current development build supports the system-proxy connection path and
-contains the Linux Xray-native TUN helper. TUN is enabled in the UI only when
-the privileged helper socket is installed and reachable. Packaging and live
-route/DNS leak verification are still tracked in
-[`DEVELOPMENT_PLAN.md`](DEVELOPMENT_PLAN.md).
+The current preview supports the system-proxy connection path on Windows,
+macOS, and Linux, and contains the Linux Xray-native TUN helper. TUN is enabled
+in the UI only when the privileged helper socket is installed and reachable.
+Native Windows/macOS TUN services and live route/DNS leak verification remain
+tracked in [`DEVELOPMENT_PLAN.md`](DEVELOPMENT_PLAN.md).
 
 ## Development
 
@@ -52,3 +52,22 @@ owner-only permissions.
 Do not use the development build as a leak-proof VPN yet. The helper contains
 DNS guarding and a fail-closed nftables kill switch, but packaging and live
 integration checks are required before that claim.
+
+## Desktop preview builds
+
+The `GUI desktop release` GitHub Actions workflow builds on each target OS
+rather than cross-compiling:
+
+- `Xrayebator-Windows-x64.exe`;
+- `Xrayebator-macOS-Intel.dmg`;
+- `Xrayebator-macOS-Apple-Silicon.dmg`.
+
+Every bundle contains the pinned Xray archive after checking its upstream
+SHA-256 file. A matching `.sha256` sidecar is published with every artifact.
+Manual workflow runs produce CI artifacts; pushing a `gui-v*` tag additionally
+creates a GitHub prerelease.
+
+These preview binaries are not yet signed or notarized. Windows SmartScreen
+and macOS Gatekeeper can therefore display an unverified-publisher warning.
+Use GitHub **Releases** for these end-user downloads; GitHub **Packages** is
+reserved for package/container registries and is not used by this workflow.

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,0 +1,34 @@
+# Xrayebator GUI
+
+Desktop client for deploying Xrayebator to a VPS and connecting through an
+Xray VLESS Reality subscription.
+
+The current development build supports the system-proxy connection path.
+Xray-native TUN is the primary target and is tracked in
+[`DEVELOPMENT_PLAN.md`](DEVELOPMENT_PLAN.md); it is not presented as complete
+until route, DNS, privilege, and leak-safety checks pass.
+
+## Development
+
+```bash
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -e '.[dev]'
+pytest
+python -m xrayebator_gui
+```
+
+The application stores server metadata in the platform user-data directory.
+SSH passwords are stored through the operating system keyring rather than in
+`servers.json`.
+
+## Current flow
+
+1. Add VPS credentials.
+2. Deploy `install.sh` and the local `xrayebator` script over SSH.
+3. Run `xrayebator quickstart --email ...` remotely.
+4. Save the returned subscription URL.
+5. Load subscription routes and connect through local Xray.
+
+Do not use the development build as a leak-proof VPN yet. TUN, DNS guarding,
+kill switch, and privileged service isolation are required before that claim.

--- a/gui/packaging/build.py
+++ b/gui/packaging/build.py
@@ -1,0 +1,131 @@
+"""Build a native Xrayebator desktop bundle on the current operating system."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+from PyInstaller.__main__ import run as run_pyinstaller
+
+from xrayebator_gui import __version__
+
+GUI_ROOT = Path(__file__).resolve().parents[1]
+BUILD_ROOT = GUI_ROOT / "build" / "packaging"
+DIST_ROOT = GUI_ROOT / "dist"
+
+
+def _make_icon() -> Path:
+    BUILD_ROOT.mkdir(parents=True, exist_ok=True)
+    canvas = Image.new("RGBA", (1024, 1024), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(canvas)
+    draw.ellipse((64, 64, 960, 960), fill=(42, 130, 218, 255))
+    width = 96
+    draw.line((330, 310, 694, 714), fill="white", width=width)
+    draw.line((694, 310, 330, 714), fill="white", width=width)
+
+    if platform.system() == "Windows":
+        icon = BUILD_ROOT / "xrayebator.ico"
+        canvas.save(
+            icon,
+            format="ICO",
+            sizes=[(16, 16), (32, 32), (48, 48), (64, 64), (256, 256)],
+        )
+        return icon
+
+    icon = BUILD_ROOT / "xrayebator.icns"
+    canvas.save(icon, format="ICNS")
+    return icon
+
+
+def _windows_version_file() -> Path:
+    parts = [int(part) for part in __version__.split(".")]
+    version = tuple((parts + [0] * 4)[:4])
+    path = BUILD_ROOT / "version_info.txt"
+    path.write_text(
+        f"""VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers={version},
+    prodvers={version},
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        '040904B0',
+        [
+          StringStruct('CompanyName', 'Xrayebator'),
+          StringStruct('FileDescription', 'Xrayebator desktop client'),
+          StringStruct('FileVersion', '{__version__}'),
+          StringStruct('InternalName', 'Xrayebator'),
+          StringStruct('OriginalFilename', 'Xrayebator.exe'),
+          StringStruct('ProductName', 'Xrayebator GUI'),
+          StringStruct('ProductVersion', '{__version__}')
+        ]
+      )
+    ]),
+    VarFileInfo([VarStruct('Translation', [1033, 1200])])
+  ]
+)
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def main() -> int:
+    system = platform.system()
+    if system not in {"Windows", "Darwin"}:
+        raise SystemExit("Desktop release bundles are built on Windows or macOS")
+    vendor_archives = list((GUI_ROOT / "vendor").glob("Xray-*.zip"))
+    if len(vendor_archives) != 1:
+        raise SystemExit(
+            "Run packaging/fetch_xray.py before building; "
+            "exactly one platform Xray archive is required"
+        )
+
+    shutil.rmtree(DIST_ROOT, ignore_errors=True)
+    icon = _make_icon()
+    arguments = [
+        str(GUI_ROOT / "packaging" / "launcher.py"),
+        "--name=Xrayebator",
+        "--noconfirm",
+        "--clean",
+        "--windowed",
+        "--noupx",
+        f"--icon={icon}",
+        f"--distpath={DIST_ROOT}",
+        f"--workpath={BUILD_ROOT / 'pyinstaller'}",
+        f"--specpath={BUILD_ROOT}",
+        f"--paths={GUI_ROOT}",
+        f"--add-data={GUI_ROOT / 'vendor'}:vendor",
+        "--collect-data=xrayebator_gui",
+        "--collect-all=keyring",
+    ]
+    if system == "Windows":
+        arguments.extend(
+            [
+                "--onefile",
+                f"--version-file={_windows_version_file()}",
+            ]
+        )
+    else:
+        arguments.extend(
+            [
+                "--onedir",
+                "--osx-bundle-identifier=com.xrayebator.desktop",
+                f"--target-arch={platform.machine()}",
+            ]
+        )
+    run_pyinstaller(arguments)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gui/packaging/checksum.py
+++ b/gui/packaging/checksum.py
@@ -1,0 +1,26 @@
+"""Write standard SHA-256 sidecar files for release artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+
+def main(paths: list[str]) -> int:
+    if not paths:
+        raise SystemExit("usage: checksum.py ARTIFACT [...]")
+    for raw_path in paths:
+        path = Path(raw_path)
+        digest = hashlib.sha256()
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1 << 20), b""):
+                digest.update(chunk)
+        sidecar = path.with_name(f"{path.name}.sha256")
+        sidecar.write_text(f"{digest.hexdigest()}  {path.name}\n", encoding="ascii")
+        print(sidecar)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/gui/packaging/constraints.txt
+++ b/gui/packaging/constraints.txt
@@ -1,3 +1,5 @@
+# 47+ dropped the macOS x86_64 wheel; source builds produce an unsafe mixed-OpenSSL bundle.
+cryptography==46.0.7
 keyring==25.7.0
 paramiko==3.5.1
 platformdirs==4.11.0

--- a/gui/packaging/constraints.txt
+++ b/gui/packaging/constraints.txt
@@ -1,0 +1,7 @@
+keyring==25.7.0
+paramiko==3.5.1
+platformdirs==4.11.0
+PySide6==6.9.3
+PySocks==1.7.1
+qrcode==7.4.2
+requests==2.32.5

--- a/gui/packaging/constraints.txt
+++ b/gui/packaging/constraints.txt
@@ -3,5 +3,7 @@ paramiko==3.5.1
 platformdirs==4.11.0
 PySide6==6.9.3
 PySocks==1.7.1
+pytest==8.4.2
 qrcode==7.4.2
 requests==2.32.5
+ruff==0.12.12

--- a/gui/packaging/fetch_xray.py
+++ b/gui/packaging/fetch_xray.py
@@ -1,0 +1,59 @@
+"""Download and verify the pinned Xray archive used by a desktop bundle."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import tempfile
+from pathlib import Path
+
+from xrayebator_gui.core.xray import (
+    XRAY_REPO,
+    XRAY_TUN_VERSION,
+    _parse_dgst,
+    _platform_asset,
+    _sha256,
+)
+
+GUI_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    asset = _platform_asset()
+    base = f"https://github.com/{XRAY_REPO}/releases/download/{XRAY_TUN_VERSION}"
+    vendor = GUI_ROOT / "vendor"
+    vendor.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="xrayebator-release-") as temp_dir:
+        temp = Path(temp_dir)
+        archive = temp / asset
+        digest_file = temp / f"{asset}.dgst"
+        _download(f"{base}/{asset}", archive)
+        _download(f"{base}/{asset}.dgst", digest_file)
+        expected = _parse_dgst(digest_file.read_text(encoding="utf-8"), asset)
+        if expected is None:
+            raise RuntimeError(f"Xray release does not publish SHA-256 for {asset}")
+        actual = _sha256(archive)
+        if actual.lower() != expected.lower():
+            raise RuntimeError(f"SHA-256 mismatch for {asset}")
+        shutil.copy2(archive, vendor / asset)
+
+    print(
+        f"Bundled Xray {XRAY_TUN_VERSION}: {asset} "
+        f"({_sha256(vendor / asset)}) on {platform.platform()}"
+    )
+    return 0
+
+
+def _download(url: str, destination: Path) -> None:
+    import requests
+
+    with requests.get(url, stream=True, timeout=180) as response:
+        response.raise_for_status()
+        with destination.open("wb") as output:
+            for chunk in response.iter_content(1 << 20):
+                output.write(chunk)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gui/packaging/launcher.py
+++ b/gui/packaging/launcher.py
@@ -1,0 +1,7 @@
+"""PyInstaller entry point kept outside the application package."""
+
+from xrayebator_gui.app import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gui/packaging/requirements-build.txt
+++ b/gui/packaging/requirements-build.txt
@@ -1,0 +1,3 @@
+build==1.3.0
+Pillow==12.3.0
+PyInstaller==6.21.0

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xrayebator-gui"
-version = "0.1.0"
+version = "0.2.0"
 description = "Desktop GUI для развёртывания Xrayebator на VPS и подключения к нему (Xray VLESS Reality)"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "xrayebator-gui"
+version = "0.1.0"
+description = "Desktop GUI для развёртывания Xrayebator на VPS и подключения к нему (Xray VLESS Reality)"
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+license = { text = "MIT" }
+dependencies = [
+    "PySide6>=6.7,<6.10",
+    "paramiko>=3.4,<4.0",
+    "requests>=2.31,<2.33",
+    "requests[socks]>=2.31,<2.33",
+    "qrcode[pil]>=7.4,<8.0",
+    "keyring>=24.3,<26.0",
+    "platformdirs>=4.2,<5.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<9.0",
+]
+
+[project.scripts]
+xrayebator-gui = "xrayebator_gui.app:main"
+
+[tool.setuptools.packages.find]
+include = ["xrayebator_gui*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Desktop GUI для развёртывания Xrayebator на VPS и подключения к нему (Xray VLESS Reality)"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
-license = { text = "MIT" }
+license = "MIT"
 dependencies = [
     "PySide6>=6.7,<6.10",
     "paramiko>=3.4,<4.0",
@@ -31,6 +31,9 @@ xrayebator-gui-helper = "xrayebator_gui.helper.service:main"
 
 [tool.setuptools.packages.find]
 include = ["xrayebator_gui*"]
+
+[tool.setuptools.package-data]
+xrayebator_gui = ["resources/linux/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/gui/pyproject.toml
+++ b/gui/pyproject.toml
@@ -22,13 +22,19 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0,<9.0",
+    "ruff>=0.12,<1.0",
 ]
 
 [project.scripts]
 xrayebator-gui = "xrayebator_gui.app:main"
+xrayebator-gui-helper = "xrayebator_gui.helper.service:main"
 
 [tool.setuptools.packages.find]
 include = ["xrayebator_gui*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"

--- a/gui/tests/test_connection.py
+++ b/gui/tests/test_connection.py
@@ -10,6 +10,7 @@ from xrayebator_gui.core.connection import (
     InvalidTransition,
     RouteSwitchError,
 )
+from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.core.subscription import VlessLink
 
 
@@ -36,13 +37,13 @@ class FakeBackend:
         self.fail_prepare = False
         self.fail_stop = False
 
-    def prepare(self, selected, mode):
-        self.calls.append(("prepare", selected.address, mode))
+    def prepare(self, selected, mode, routing_profile):
+        self.calls.append(("prepare", selected.address, mode, routing_profile))
         if self.fail_prepare:
             raise RuntimeError("prepare failed")
 
-    def start(self, selected, mode):
-        self.calls.append(("start", selected.address, mode))
+    def start(self, selected, mode, routing_profile):
+        self.calls.append(("start", selected.address, mode, routing_profile))
 
     def verify(self):
         self.calls.append(("verify",))
@@ -51,8 +52,8 @@ class FakeBackend:
             raise result
         return result
 
-    def replace(self, selected, mode):
-        self.calls.append(("replace", selected.address, mode))
+    def replace(self, selected, mode, routing_profile):
+        self.calls.append(("replace", selected.address, mode, routing_profile))
 
     def stop(self):
         self.calls.append(("stop",))
@@ -152,3 +153,36 @@ def test_switch_requires_active_connection():
 
     with pytest.raises(InvalidTransition):
         controller.switch_route(route("two.example"))
+
+
+def test_profile_switch_is_verified_and_keeps_route():
+    backend = FakeBackend()
+    backend.verify_results = ["203.0.113.1", "203.0.113.2"]
+    controller = ConnectionController(backend)
+    original = route("one.example")
+    controller.connect(original, ConnectionMode.TUN)
+
+    result = controller.switch_profile(RoutingProfile.SMART_RU)
+
+    assert result.state == ConnectionState.CONNECTED
+    assert result.route == original
+    assert result.routing_profile == RoutingProfile.SMART_RU
+    assert (
+        "replace",
+        "one.example",
+        ConnectionMode.TUN,
+        RoutingProfile.SMART_RU,
+    ) in backend.calls
+
+
+def test_failed_profile_switch_restores_previous_profile():
+    backend = FakeBackend()
+    backend.verify_results = ["203.0.113.1", None, "203.0.113.1"]
+    controller = ConnectionController(backend)
+    controller.connect(route("one.example"), ConnectionMode.TUN)
+
+    with pytest.raises(RouteSwitchError, match="восстановлены"):
+        controller.switch_profile(RoutingProfile.SMART_RU)
+
+    assert controller.snapshot.state == ConnectionState.CONNECTED
+    assert controller.snapshot.routing_profile == RoutingProfile.FULL

--- a/gui/tests/test_connection.py
+++ b/gui/tests/test_connection.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+from xrayebator_gui.core.connection import (
+    ConnectionController,
+    ConnectionError,
+    ConnectionMode,
+    ConnectionState,
+    InvalidTransition,
+    RouteSwitchError,
+)
+from xrayebator_gui.core.subscription import VlessLink
+
+
+def route(name: str, port: int = 443) -> VlessLink:
+    return VlessLink(
+        raw=f"vless://uuid@{name}:{port}?security=reality#{name}",
+        address=name,
+        port=port,
+        uuid="uuid",
+        network="tcp",
+        security="reality",
+        sni=name,
+        public_key="public-key",
+        short_id="0123456789abcdef",
+        flow="xtls-rprx-vision",
+        remark=name,
+    )
+
+
+class FakeBackend:
+    def __init__(self):
+        self.calls: list[tuple] = []
+        self.verify_results: list[object] = ["203.0.113.1"]
+        self.fail_prepare = False
+        self.fail_stop = False
+
+    def prepare(self, selected, mode):
+        self.calls.append(("prepare", selected.address, mode))
+        if self.fail_prepare:
+            raise RuntimeError("prepare failed")
+
+    def start(self, selected, mode):
+        self.calls.append(("start", selected.address, mode))
+
+    def verify(self):
+        self.calls.append(("verify",))
+        result = self.verify_results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def replace(self, selected, mode):
+        self.calls.append(("replace", selected.address, mode))
+
+    def stop(self):
+        self.calls.append(("stop",))
+        if self.fail_stop:
+            raise RuntimeError("stop failed")
+
+
+def test_connect_and_disconnect_emit_ordered_states():
+    backend = FakeBackend()
+    controller = ConnectionController(backend)
+    states = []
+    controller.subscribe(lambda snapshot: states.append(snapshot.state))
+
+    connected = controller.connect(route("one.example"), ConnectionMode.SYSTEM_PROXY)
+    disconnected = controller.disconnect()
+
+    assert connected.state == ConnectionState.CONNECTED
+    assert connected.external_ip == "203.0.113.1"
+    assert disconnected.state == ConnectionState.DISCONNECTED
+    assert states == [
+        ConnectionState.DISCONNECTED,
+        ConnectionState.PREPARING,
+        ConnectionState.CONNECTING,
+        ConnectionState.VERIFYING,
+        ConnectionState.CONNECTED,
+        ConnectionState.DISCONNECTING,
+        ConnectionState.DISCONNECTED,
+    ]
+
+
+def test_failed_connect_stops_backend_and_enters_error():
+    backend = FakeBackend()
+    backend.fail_prepare = True
+    controller = ConnectionController(backend)
+
+    with pytest.raises(ConnectionError, match="prepare failed"):
+        controller.connect(route("one.example"), ConnectionMode.SYSTEM_PROXY)
+
+    assert controller.snapshot.state == ConnectionState.ERROR
+    assert controller.snapshot.error == "prepare failed"
+    assert backend.calls[-1] == ("stop",)
+
+
+def test_route_switch_commits_verified_candidate():
+    backend = FakeBackend()
+    backend.verify_results = ["203.0.113.1", "203.0.113.2"]
+    controller = ConnectionController(backend)
+    controller.connect(route("one.example"), ConnectionMode.SYSTEM_PROXY)
+
+    result = controller.switch_route(route("two.example", 8443))
+
+    assert result.state == ConnectionState.CONNECTED
+    assert result.route.address == "two.example"
+    assert result.external_ip == "203.0.113.2"
+    assert ("stop",) not in backend.calls[4:]
+
+
+def test_route_switch_rolls_back_to_last_known_good_route():
+    backend = FakeBackend()
+    backend.verify_results = [
+        "203.0.113.1",
+        None,
+        "203.0.113.1",
+    ]
+    controller = ConnectionController(backend)
+    original = route("one.example")
+    controller.connect(original, ConnectionMode.SYSTEM_PROXY)
+
+    with pytest.raises(RouteSwitchError, match="восстановлен"):
+        controller.switch_route(route("two.example", 8443))
+
+    assert controller.snapshot.state == ConnectionState.CONNECTED
+    assert controller.snapshot.route == original
+    assert controller.snapshot.external_ip == "203.0.113.1"
+    assert controller.snapshot.error is not None
+
+
+def test_route_switch_enters_error_when_candidate_and_rollback_fail():
+    backend = FakeBackend()
+    backend.verify_results = [
+        "203.0.113.1",
+        RuntimeError("candidate failed"),
+        RuntimeError("rollback failed"),
+    ]
+    controller = ConnectionController(backend)
+    controller.connect(route("one.example"), ConnectionMode.SYSTEM_PROXY)
+
+    with pytest.raises(RouteSwitchError, match="откат также не удался"):
+        controller.switch_route(route("two.example"))
+
+    assert controller.snapshot.state == ConnectionState.ERROR
+    assert controller.snapshot.route is None
+
+
+def test_switch_requires_active_connection():
+    controller = ConnectionController(FakeBackend())
+
+    with pytest.raises(InvalidTransition):
+        controller.switch_route(route("two.example"))

--- a/gui/tests/test_deploy.py
+++ b/gui/tests/test_deploy.py
@@ -8,6 +8,7 @@ from xrayebator_gui.core.deploy import (
     DeployError,
     Deployer,
     check_os_supported,
+    redact_log_line,
 )
 
 
@@ -132,3 +133,17 @@ def test_supported_os(text, expected):
 def test_unsupported_os_has_actionable_message():
     with pytest.raises(DeployError, match="Поддерживаются"):
         check_os_supported('ID="centos"\nVERSION_ID="9"\n')
+
+
+def test_deploy_log_redacts_subscription_and_vless_secrets():
+    json_line = json.dumps(
+        {
+            "ok": True,
+            "subscription_url": "https://vpn.example/sub/bearer-token",
+        }
+    )
+
+    assert "bearer-token" not in redact_log_line(json_line)
+    assert "uuid-secret" not in redact_log_line(
+        "route: vless://uuid-secret@vpn.example:443?security=reality"
+    )

--- a/gui/tests/test_deploy.py
+++ b/gui/tests/test_deploy.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xrayebator_gui.core.deploy import (
+    DeployError,
+    Deployer,
+    check_os_supported,
+)
+
+
+class FakeSSH:
+    def __init__(self, *, quickstart_ok=True, staging=None):
+        self.quickstart_ok = quickstart_ok
+        self.staging = staging or "/tmp/xrayebator-deploy.A1b2C3d4"
+        self.connect_kwargs = None
+        self.commands = []
+        self.uploads = []
+        self.closed = False
+
+    def connect(self, host, port, user, **kwargs):
+        self.connect_kwargs = (host, port, user, kwargs)
+
+    def run_streaming(
+        self,
+        command,
+        on_line=None,
+        timeout=600,
+        *,
+        privileged=True,
+    ):
+        self.commands.append((command, privileged))
+        lines = []
+        if command == "cat /etc/os-release":
+            lines = ['ID="debian"', 'VERSION_ID="12"']
+        elif command.startswith("mktemp "):
+            lines = [self.staging]
+        elif "quickstart" in command:
+            lines = [
+                "quickstart output",
+                json.dumps(
+                    {
+                        "ok": self.quickstart_ok,
+                        "subscription_url": "https://vpn.example/sub/token",
+                        "profile": "happ",
+                    }
+                ),
+            ]
+        if on_line:
+            for line in lines:
+                on_line(line)
+        return 0
+
+    def upload(self, local_path, remote_path):
+        self.uploads.append((local_path, remote_path))
+
+    def close(self):
+        self.closed = True
+
+
+def repo(tmp_path):
+    (tmp_path / "install.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    (tmp_path / "xrayebator").write_text("#!/bin/sh\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_deploy_uses_user_owned_staging_and_privileged_install(tmp_path):
+    ssh = FakeSSH()
+    deployer = Deployer(
+        ssh,
+        host="vpn.example.com",
+        user="alice",
+        password=None,
+        key_path="~/.ssh/id_ed25519",
+        sudo_password="sudo-secret",
+        email="alice@example.com",
+        repo_root=repo(tmp_path),
+    )
+
+    result = deployer.run()
+
+    assert result["ok"] is True
+    assert ssh.connect_kwargs[3]["sudo_password"] == "sudo-secret"
+    assert ssh.commands[0] == ("cat /etc/os-release", False)
+    assert ssh.commands[1][0].startswith("mktemp -d ")
+    assert ssh.commands[1][1] is False
+    assert [str(remote) for _, remote in ssh.uploads] == [
+        f"{ssh.staging}/install.sh",
+        f"{ssh.staging}/xrayebator",
+    ]
+    install_commands = [
+        command
+        for command, privileged in ssh.commands
+        if privileged and command != ""
+    ]
+    assert any(command.startswith("bash ") for command in install_commands)
+    assert any("quickstart --email alice@example.com" in command for command in install_commands)
+    assert ssh.commands[-1] == (f"rm -rf -- {ssh.staging}", False)
+    assert ssh.closed
+
+
+def test_deploy_rejects_untrusted_staging_path_and_still_closes(tmp_path):
+    ssh = FakeSSH(staging="/tmp/safe; touch /tmp/pwned")
+    deployer = Deployer(
+        ssh,
+        host="vpn.example.com",
+        email="alice@example.com",
+        repo_root=repo(tmp_path),
+    )
+
+    with pytest.raises(DeployError, match="небезопасный"):
+        deployer.run()
+
+    assert not ssh.uploads
+    assert ssh.closed
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ('ID=debian\nVERSION_ID="12"\n', ("debian", "12")),
+        ('ID="ubuntu"\nVERSION_ID="24.04"\n', ("ubuntu", "24.04")),
+    ],
+)
+def test_supported_os(text, expected):
+    assert check_os_supported(text) == expected
+
+
+def test_unsupported_os_has_actionable_message():
+    with pytest.raises(DeployError, match="Поддерживаются"):
+        check_os_supported('ID="centos"\nVERSION_ID="9"\n')

--- a/gui/tests/test_deploy.py
+++ b/gui/tests/test_deploy.py
@@ -91,12 +91,13 @@ def test_deploy_uses_user_owned_staging_and_privileged_install(tmp_path):
         f"{ssh.staging}/xrayebator",
     ]
     install_commands = [
-        command
-        for command, privileged in ssh.commands
-        if privileged and command != ""
+        command for command, privileged in ssh.commands if privileged and command != ""
     ]
     assert any(command.startswith("bash ") for command in install_commands)
-    assert any("quickstart --email alice@example.com" in command for command in install_commands)
+    assert any(
+        "quickstart --email alice@example.com" in command
+        for command in install_commands
+    )
     assert ssh.commands[-1] == (f"rm -rf -- {ssh.staging}", False)
     assert ssh.closed
 

--- a/gui/tests/test_helper_install.py
+++ b/gui/tests/test_helper_install.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from xrayebator_gui.core import helper_install
+
+
+def test_installer_is_packaged_with_application():
+    path = helper_install.linux_installer_path()
+
+    assert path.is_file()
+    assert path.name == "install-helper.sh"
+
+
+def test_installer_uses_pkexec_without_shell(monkeypatch):
+    calls = []
+    monkeypatch.setattr(helper_install.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(helper_install.shutil, "which", lambda name: "/usr/bin/pkexec")
+    monkeypatch.setattr(
+        helper_install.pwd,
+        "getpwuid",
+        lambda uid: SimpleNamespace(pw_name="alice"),
+    )
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(returncode=0, stdout="installed", stderr="")
+
+    monkeypatch.setattr(helper_install.subprocess, "run", fake_run)
+
+    assert helper_install.install_linux_helper() == "installed"
+    args, kwargs = calls[0]
+    assert args[:2] == ["/usr/bin/pkexec", "bash"]
+    assert args[-2:] == ["--user", "alice"]
+    assert "shell" not in kwargs

--- a/gui/tests/test_helper_install.py
+++ b/gui/tests/test_helper_install.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 from xrayebator_gui.core import helper_install
 
 
@@ -16,15 +14,15 @@ def test_installer_uses_pkexec_without_shell(monkeypatch):
     calls = []
     monkeypatch.setattr(helper_install.platform, "system", lambda: "Linux")
     monkeypatch.setattr(helper_install.shutil, "which", lambda name: "/usr/bin/pkexec")
-    monkeypatch.setattr(
-        helper_install.pwd,
-        "getpwuid",
-        lambda uid: SimpleNamespace(pw_name="alice"),
-    )
+    monkeypatch.setattr(helper_install.getpass, "getuser", lambda: "alice")
 
     def fake_run(args, **kwargs):
         calls.append((args, kwargs))
-        return SimpleNamespace(returncode=0, stdout="installed", stderr="")
+        return type(
+            "Result",
+            (),
+            {"returncode": 0, "stdout": "installed", "stderr": ""},
+        )()
 
     monkeypatch.setattr(helper_install.subprocess, "run", fake_run)
 

--- a/gui/tests/test_helper_protocol.py
+++ b/gui/tests/test_helper_protocol.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xrayebator_gui.core.helper_protocol import (
+    ProtocolError,
+    decode_request,
+    decode_response,
+    encode_request,
+    encode_response,
+)
+from xrayebator_gui.core.subscription import parse_link
+
+
+ROUTE = (
+    "vless://11111111-1111-1111-1111-111111111111@vpn.example.com:443"
+    "?type=tcp&security=reality&sni=www.example.com&fp=chrome"
+    "&pbk=public&sid=0123456789abcdef&flow=xtls-rprx-vision#Vision"
+)
+
+
+def test_protocol_round_trip_keeps_only_canonical_vless_url():
+    route = parse_link(ROUTE)
+    assert route is not None
+
+    request = decode_request(encode_request("connect", route))
+
+    assert request.action == "connect"
+    assert request.route is not None
+    assert request.route.raw == ROUTE
+
+
+def test_protocol_rejects_unknown_fields():
+    payload = {
+        "version": 1,
+        "id": "abc123",
+        "action": "status",
+        "command": "rm -rf /",
+    }
+
+    with pytest.raises(ProtocolError, match="Неизвестные поля"):
+        decode_request(json.dumps(payload).encode())
+
+
+def test_protocol_rejects_route_for_status():
+    payload = {
+        "version": 1,
+        "id": "abc123",
+        "action": "status",
+        "route": ROUTE,
+    }
+
+    with pytest.raises(ProtocolError, match="не принимает"):
+        decode_request(json.dumps(payload).encode())
+
+
+def test_response_id_must_match():
+    response = encode_response(
+        "one",
+        ok=True,
+        state="connected",
+        external_ip="203.0.113.1",
+    )
+
+    with pytest.raises(ProtocolError, match="другой request id"):
+        decode_response(response, "two")

--- a/gui/tests/test_helper_protocol.py
+++ b/gui/tests/test_helper_protocol.py
@@ -11,6 +11,7 @@ from xrayebator_gui.core.helper_protocol import (
     encode_request,
     encode_response,
 )
+from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.core.subscription import parse_link
 
 
@@ -25,11 +26,12 @@ def test_protocol_round_trip_keeps_only_canonical_vless_url():
     route = parse_link(ROUTE)
     assert route is not None
 
-    request = decode_request(encode_request("connect", route))
+    request = decode_request(encode_request("connect", route, RoutingProfile.SMART_RU))
 
     assert request.action == "connect"
     assert request.route is not None
     assert request.route.raw == ROUTE
+    assert request.routing_profile == RoutingProfile.SMART_RU
 
 
 def test_protocol_rejects_unknown_fields():
@@ -50,6 +52,7 @@ def test_protocol_rejects_route_for_status():
         "id": "abc123",
         "action": "status",
         "route": ROUTE,
+        "routing_profile": "full",
     }
 
     with pytest.raises(ProtocolError, match="не принимает"):

--- a/gui/tests/test_helper_service.py
+++ b/gui/tests/test_helper_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from xrayebator_gui.core.helper_protocol import HelperRequest
+from xrayebator_gui.helper.service import HelperApplication
+
+
+class FakeRuntime:
+    def __init__(self):
+        self.calls = []
+
+    def status(self):
+        self.calls.append(("status",))
+        return {"state": "disconnected", "external_ip": None, "error": None}
+
+    def connect(self, route):
+        self.calls.append(("connect", route))
+        return {"state": "connected", "external_ip": None, "error": None}
+
+    def switch(self, route):
+        self.calls.append(("switch", route))
+        return {"state": "connected", "external_ip": None, "error": None}
+
+    def verify(self):
+        self.calls.append(("verify",))
+        return {
+            "state": "connected",
+            "external_ip": "203.0.113.1",
+            "error": None,
+        }
+
+    def disconnect(self):
+        self.calls.append(("disconnect",))
+        return {"state": "disconnected", "external_ip": None, "error": None}
+
+
+def test_application_dispatches_only_typed_actions():
+    runtime = FakeRuntime()
+    app = HelperApplication(runtime)
+
+    result = app.handle(HelperRequest("abc", "status"))
+
+    assert result["state"] == "disconnected"
+    assert runtime.calls == [("status",)]

--- a/gui/tests/test_helper_service.py
+++ b/gui/tests/test_helper_service.py
@@ -12,12 +12,16 @@ class FakeRuntime:
         self.calls.append(("status",))
         return {"state": "disconnected", "external_ip": None, "error": None}
 
-    def connect(self, route):
-        self.calls.append(("connect", route))
+    def connect(self, route, routing_profile):
+        self.calls.append(("connect", route, routing_profile))
         return {"state": "connected", "external_ip": None, "error": None}
 
-    def switch(self, route):
-        self.calls.append(("switch", route))
+    def selftest(self):
+        self.calls.append(("selftest",))
+        return {"state": "disconnected", "external_ip": None, "error": None}
+
+    def switch(self, route, routing_profile):
+        self.calls.append(("switch", route, routing_profile))
         return {"state": "connected", "external_ip": None, "error": None}
 
     def verify(self):
@@ -47,3 +51,13 @@ def test_explicit_uid_authorization_does_not_trust_shared_group():
     assert authorized_peer(1000, 100, 100, allowed_uid=1000)
     assert not authorized_peer(1001, 100, 100, allowed_uid=1000)
     assert authorized_peer(0, 0, 100, allowed_uid=1000)
+
+
+def test_application_dispatches_selftest():
+    runtime = FakeRuntime()
+    app = HelperApplication(runtime)
+
+    result = app.handle(HelperRequest("abc", "selftest"))
+
+    assert result["state"] == "disconnected"
+    assert runtime.calls == [("selftest",)]

--- a/gui/tests/test_helper_service.py
+++ b/gui/tests/test_helper_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from xrayebator_gui.core.helper_protocol import HelperRequest
-from xrayebator_gui.helper.service import HelperApplication
+from xrayebator_gui.helper.service import HelperApplication, authorized_peer
 
 
 class FakeRuntime:
@@ -41,3 +41,9 @@ def test_application_dispatches_only_typed_actions():
 
     assert result["state"] == "disconnected"
     assert runtime.calls == [("status",)]
+
+
+def test_explicit_uid_authorization_does_not_trust_shared_group():
+    assert authorized_peer(1000, 100, 100, allowed_uid=1000)
+    assert not authorized_peer(1001, 100, 100, allowed_uid=1000)
+    assert authorized_peer(0, 0, 100, allowed_uid=1000)

--- a/gui/tests/test_helper_state.py
+++ b/gui/tests/test_helper_state.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from xrayebator_gui.core.subscription import parse_link
+from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.helper.state import RouteStateStore, StateError
 
 
@@ -21,12 +22,13 @@ def test_state_round_trip_is_owner_only(tmp_path):
     route = parse_link(ROUTE)
     assert route is not None
 
-    store.save(route, "198.51.100.20")
+    store.save(route, "198.51.100.20", RoutingProfile.SMART_RU)
     restored = store.load()
 
     assert restored is not None
     assert restored.route.raw == route.raw
     assert restored.resolved_address == "198.51.100.20"
+    assert restored.routing_profile == RoutingProfile.SMART_RU
     assert path.stat().st_mode & 0o777 == 0o600
 
 
@@ -35,7 +37,7 @@ def test_state_rejects_group_readable_secret(tmp_path):
     store = RouteStateStore(path, expected_uid=os.getuid())
     route = parse_link(ROUTE)
     assert route is not None
-    store.save(route, "198.51.100.20")
+    store.save(route, "198.51.100.20", RoutingProfile.FULL)
     path.chmod(0o640)
 
     with pytest.raises(StateError, match="owner/mode"):

--- a/gui/tests/test_helper_state.py
+++ b/gui/tests/test_helper_state.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from xrayebator_gui.core.subscription import parse_link
+from xrayebator_gui.helper.state import RouteStateStore, StateError
+
+
+ROUTE = (
+    "vless://11111111-1111-1111-1111-111111111111@vpn.example.com:443"
+    "?type=tcp&security=reality&sni=www.example.com"
+    "&pbk=public&sid=0123456789abcdef#Vision"
+)
+
+
+def test_state_round_trip_is_owner_only(tmp_path):
+    path = tmp_path / "state" / "last-route.json"
+    store = RouteStateStore(path, expected_uid=os.getuid())
+    route = parse_link(ROUTE)
+    assert route is not None
+
+    store.save(route, "198.51.100.20")
+    restored = store.load()
+
+    assert restored is not None
+    assert restored.route.raw == route.raw
+    assert restored.resolved_address == "198.51.100.20"
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_state_rejects_group_readable_secret(tmp_path):
+    path = tmp_path / "last-route.json"
+    store = RouteStateStore(path, expected_uid=os.getuid())
+    route = parse_link(ROUTE)
+    assert route is not None
+    store.save(route, "198.51.100.20")
+    path.chmod(0o640)
+
+    with pytest.raises(StateError, match="owner/mode"):
+        store.load()

--- a/gui/tests/test_latency.py
+++ b/gui/tests/test_latency.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from xrayebator_gui.core import latency
+from xrayebator_gui.core.subscription import VlessLink
+
+
+def route(raw: str, host: str, port: int) -> VlessLink:
+    return VlessLink(
+        raw=raw,
+        address=host,
+        port=port,
+        uuid="uuid",
+    )
+
+
+def test_probe_routes_deduplicates_shared_endpoints(monkeypatch):
+    calls = []
+
+    def fake_probe(host, port, *, timeout):
+        calls.append((host, port, timeout))
+        return 42
+
+    monkeypatch.setattr(latency, "probe_endpoint", fake_probe)
+    routes = [
+        route("one", "vpn.example.com", 443),
+        route("two", "vpn.example.com", 443),
+        route("three", "vpn.example.com", 8443),
+    ]
+
+    result = latency.probe_routes(routes, timeout=1.5)
+
+    assert result == {"one": 42, "two": 42, "three": 42}
+    assert sorted(calls) == [
+        ("vpn.example.com", 443, 1.5),
+        ("vpn.example.com", 8443, 1.5),
+    ]

--- a/gui/tests/test_linux_network.py
+++ b/gui/tests/test_linux_network.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from xrayebator_gui.helper.linux_network import (
+    NetworkError,
+    build_nft_rules,
+)
+
+
+def test_nft_guard_allows_only_loopback_tun_mark_and_dhcp():
+    rules = build_nft_rules("xrayebator0", 0x5852)
+
+    assert 'oifname "lo" accept' in rules
+    assert 'oifname "xrayebator0" accept' in rules
+    assert f"meta mark {0x5852} accept" in rules
+    assert "udp sport 68 udp dport 67 accept" in rules
+    assert rules.rstrip().endswith("}")
+    assert "reject" in rules
+
+
+@pytest.mark.parametrize(
+    "interface",
+    ["", "tun interface", "../../eth0", "a" * 16, 'tun"evil'],
+)
+def test_nft_guard_rejects_unsafe_interface_name(interface):
+    with pytest.raises(NetworkError, match="имя"):
+        build_nft_rules(interface, 1)
+
+
+@pytest.mark.parametrize("mark", [0, -1, 0x1_0000_0000])
+def test_nft_guard_rejects_invalid_mark(mark):
+    with pytest.raises(NetworkError, match="mark"):
+        build_nft_rules("xrayebator0", mark)

--- a/gui/tests/test_linux_network.py
+++ b/gui/tests/test_linux_network.py
@@ -14,6 +14,8 @@ def test_nft_guard_allows_only_loopback_tun_mark_and_dhcp():
     assert 'oifname "lo" accept' in rules
     assert 'oifname "xrayebator0" accept' in rules
     assert f"meta mark {0x5852} accept" in rules
+    assert "udp dport 53 dnat ip to 1.1.1.1" in rules
+    assert "tcp dport 53 dnat ip6 to 2606:4700:4700::1111" in rules
     assert "udp sport 68 udp dport 67 accept" in rules
     assert rules.rstrip().endswith("}")
     assert "reject" in rules

--- a/gui/tests/test_local_proxy.py
+++ b/gui/tests/test_local_proxy.py
@@ -4,6 +4,7 @@ import pytest
 
 from xrayebator_gui.core import local_proxy
 from xrayebator_gui.core.connection import ConnectionMode
+from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.core.subscription import VlessLink
 from xrayebator_gui.core.xray import XrayError
 
@@ -55,8 +56,16 @@ def test_backend_restores_previous_proxy_on_stop(monkeypatch, tmp_path):
         process_factory=lambda binary: process,
     )
 
-    backend.prepare(route(), ConnectionMode.SYSTEM_PROXY)
-    backend.start(route(), ConnectionMode.SYSTEM_PROXY)
+    backend.prepare(
+        route(),
+        ConnectionMode.SYSTEM_PROXY,
+        RoutingProfile.FULL,
+    )
+    backend.start(
+        route(),
+        ConnectionMode.SYSTEM_PROXY,
+        RoutingProfile.FULL,
+    )
     backend.stop()
 
     assert restored == [snapshot]
@@ -78,10 +87,18 @@ def test_backend_restores_snapshot_when_proxy_enable_fails(monkeypatch, tmp_path
         ensure_binary_fn=lambda: tmp_path / "xray",
         process_factory=lambda binary: process,
     )
-    backend.prepare(route(), ConnectionMode.SYSTEM_PROXY)
+    backend.prepare(
+        route(),
+        ConnectionMode.SYSTEM_PROXY,
+        RoutingProfile.FULL,
+    )
 
     with pytest.raises(XrayError, match="proxy"):
-        backend.start(route(), ConnectionMode.SYSTEM_PROXY)
+        backend.start(
+            route(),
+            ConnectionMode.SYSTEM_PROXY,
+            RoutingProfile.FULL,
+        )
 
     assert restored == [snapshot]
     assert process.stop_calls == 1

--- a/gui/tests/test_local_proxy.py
+++ b/gui/tests/test_local_proxy.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+
+from xrayebator_gui.core import local_proxy
+from xrayebator_gui.core.connection import ConnectionMode
+from xrayebator_gui.core.subscription import VlessLink
+from xrayebator_gui.core.xray import XrayError
+
+
+def route() -> VlessLink:
+    return VlessLink(
+        raw="vless://uuid@vpn.example.com:443",
+        address="vpn.example.com",
+        port=443,
+        uuid="uuid",
+        network="tcp",
+        security="reality",
+        sni="www.example.com",
+        public_key="public",
+        short_id="0123456789abcdef",
+        remark="Vision",
+    )
+
+
+class FakeProcess:
+    def __init__(self, binary):
+        self.binary = binary
+        self.started = []
+        self.stop_calls = 0
+
+    def start(self, config):
+        self.started.append(config)
+
+    def stop(self):
+        self.stop_calls += 1
+
+    def health_check(self):
+        return "203.0.113.10"
+
+
+def test_backend_restores_previous_proxy_on_stop(monkeypatch, tmp_path):
+    snapshot = object()
+    restored = []
+    monkeypatch.setattr(local_proxy.proxy, "capture", lambda: snapshot)
+    monkeypatch.setattr(local_proxy.proxy, "enable", lambda **kwargs: True)
+    monkeypatch.setattr(
+        local_proxy.proxy,
+        "restore",
+        lambda saved: restored.append(saved) or True,
+    )
+    process = FakeProcess(tmp_path / "xray")
+    backend = local_proxy.LocalProxyBackend(
+        ensure_binary_fn=lambda: tmp_path / "xray",
+        process_factory=lambda binary: process,
+    )
+
+    backend.prepare(route(), ConnectionMode.SYSTEM_PROXY)
+    backend.start(route(), ConnectionMode.SYSTEM_PROXY)
+    backend.stop()
+
+    assert restored == [snapshot]
+    assert process.stop_calls == 1
+
+
+def test_backend_restores_snapshot_when_proxy_enable_fails(monkeypatch, tmp_path):
+    snapshot = object()
+    restored = []
+    monkeypatch.setattr(local_proxy.proxy, "capture", lambda: snapshot)
+    monkeypatch.setattr(local_proxy.proxy, "enable", lambda **kwargs: False)
+    monkeypatch.setattr(
+        local_proxy.proxy,
+        "restore",
+        lambda saved: restored.append(saved) or True,
+    )
+    process = FakeProcess(tmp_path / "xray")
+    backend = local_proxy.LocalProxyBackend(
+        ensure_binary_fn=lambda: tmp_path / "xray",
+        process_factory=lambda binary: process,
+    )
+    backend.prepare(route(), ConnectionMode.SYSTEM_PROXY)
+
+    with pytest.raises(XrayError, match="proxy"):
+        backend.start(route(), ConnectionMode.SYSTEM_PROXY)
+
+    assert restored == [snapshot]
+    assert process.stop_calls == 1

--- a/gui/tests/test_proxy.py
+++ b/gui/tests/test_proxy.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from xrayebator_gui.core import proxy
+
+
+def test_linux_capture_and_restore_puts_mode_last(monkeypatch):
+    values = {
+        ("org.gnome.system.proxy", "mode"): "'auto'",
+        ("org.gnome.system.proxy.http", "host"): "'old-http'",
+        ("org.gnome.system.proxy.http", "port"): "3128",
+        ("org.gnome.system.proxy.https", "host"): "'old-https'",
+        ("org.gnome.system.proxy.https", "port"): "4443",
+    }
+    calls = []
+    monkeypatch.setattr(proxy.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        proxy,
+        "_gsettings_get",
+        lambda schema, key: values[(schema, key)],
+    )
+    monkeypatch.setattr(
+        proxy,
+        "_gsettings",
+        lambda *args: calls.append(args) or True,
+    )
+
+    snapshot = proxy.capture()
+    assert proxy.restore(snapshot)
+
+    assert calls[-1] == (
+        "set",
+        "org.gnome.system.proxy",
+        "mode",
+        "'auto'",
+    )
+    assert len(calls) == 5
+
+
+def test_restore_rejects_snapshot_from_another_system(monkeypatch):
+    monkeypatch.setattr(proxy.platform, "system", lambda: "Linux")
+    snapshot = proxy.ProxySnapshot("Windows", {})
+
+    try:
+        proxy.restore(snapshot)
+    except proxy.UnsupportedPlatform as exc:
+        assert "Windows" in str(exc)
+    else:
+        raise AssertionError("restore accepted a snapshot from another OS")

--- a/gui/tests/test_servers.py
+++ b/gui/tests/test_servers.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from xrayebator_gui.core import servers
+from xrayebator_gui.core.servers import ServerStore
+
+
+def test_server_metadata_with_subscription_is_owner_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(servers.keyring, "set_password", lambda *args: None)
+    store = ServerStore(tmp_path)
+
+    saved = store.add(
+        name="VPN",
+        host="vpn.example.com",
+        port=22,
+        user="root",
+        auth_type="password",
+        password="ssh-secret",
+        subscription_url="https://vpn.example.com/sub/bearer-secret",
+    )
+
+    data_file = tmp_path / "servers.json"
+    assert data_file.stat().st_mode & 0o777 == 0o600
+    text = data_file.read_text(encoding="utf-8")
+    assert "bearer-secret" in text
+    assert "ssh-secret" not in text
+    assert store.get(saved["id"]) is not None

--- a/gui/tests/test_subscription.py
+++ b/gui/tests/test_subscription.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import base64
+
+from xrayebator_gui.core.subscription import parse, pick_default
+
+
+VISION = (
+    "vless://11111111-1111-1111-1111-111111111111@vpn.example.com:443"
+    "?type=tcp&security=reality&sni=www.example.com&fp=chrome"
+    "&pbk=public&sid=0123456789abcdef&flow=xtls-rprx-vision#Vision"
+)
+XHTTP = (
+    "vless://22222222-2222-2222-2222-222222222222@vpn.example.com:8443"
+    "?type=xhttp&security=reality&sni=www.example.com&fp=firefox"
+    "&pbk=public&sid=abcdef0123456789&path=%2Fxhttp#XHTTP"
+)
+
+
+def test_parse_plain_subscription_and_pick_vision():
+    routes = parse(f"# ignored\n{XHTTP}\n{VISION}\n")
+
+    assert [route.remark for route in routes] == ["XHTTP", "Vision"]
+    assert routes[0].path == "/xhttp"
+    assert pick_default(routes) == routes[1]
+
+
+def test_parse_base64_subscription():
+    encoded = base64.b64encode(f"{VISION}\n{XHTTP}\n".encode()).decode()
+
+    routes = parse(encoded)
+
+    assert len(routes) == 2
+    assert routes[0].flow == "xtls-rprx-vision"

--- a/gui/tests/test_tun_runtime.py
+++ b/gui/tests/test_tun_runtime.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import pytest
+
+from xrayebator_gui.core.subscription import parse_link
+from xrayebator_gui.helper.runtime import TunRuntime, TunRuntimeError
+from xrayebator_gui.helper.state import StoredRoute
+
+
+ROUTE_ONE = (
+    "vless://11111111-1111-1111-1111-111111111111@one.example.com:443"
+    "?type=tcp&security=reality&sni=www.example.com"
+    "&pbk=public&sid=0123456789abcdef#One"
+)
+ROUTE_TWO = ROUTE_ONE.replace("one.example.com", "two.example.com").replace(
+    "#One", "#Two"
+)
+
+
+class FakeNetwork:
+    def __init__(self):
+        self.calls = []
+        self.guarded = False
+
+    def guard_exists(self):
+        return self.guarded
+
+    def check_dependencies(self):
+        self.calls.append(("check",))
+
+    def enable_guard(self, interface, mark):
+        self.guarded = True
+        self.calls.append(("guard-on", interface, mark))
+
+    def disable_guard(self):
+        self.guarded = False
+        self.calls.append(("guard-off",))
+
+    def configure_dns(self, interface):
+        self.calls.append(("dns-on", interface))
+
+    def restore_dns(self, interface):
+        self.calls.append(("dns-off", interface))
+
+
+class FakeProcess:
+    def __init__(self, address, *, fail=False):
+        self.address = address
+        self.fail = fail
+        self.running = False
+        self.stop_calls = 0
+
+    def start(self, config):
+        if self.fail:
+            raise TunRuntimeError("candidate failed")
+        self.running = True
+
+    def stop(self):
+        self.running = False
+        self.stop_calls += 1
+
+    def is_running(self):
+        return self.running
+
+    def health_check_tun(self):
+        return "203.0.113.20" if self.running else None
+
+
+class FakeStateStore:
+    def __init__(self, stored=None):
+        self.stored = stored
+        self.saved = []
+        self.remove_calls = 0
+
+    def save(self, route, address):
+        self.saved.append((route, address))
+        self.stored = StoredRoute(route, address)
+
+    def load(self):
+        return self.stored
+
+    def remove(self):
+        self.remove_calls += 1
+        self.stored = None
+
+
+def make_runtime(
+    network,
+    runtime_dir,
+    *,
+    fail_addresses=None,
+    state_store=None,
+):
+    processes = []
+    fail_addresses = fail_addresses or set()
+
+    def factory(binary, config_path, stderr_path):
+        # The resolver result is consumed later in config.start; use call order.
+        address = str(len(processes))
+        process = FakeProcess(address, fail=address in fail_addresses)
+        processes.append(process)
+        return process
+
+    runtime = TunRuntime(
+        network=network,
+        runtime_dir=runtime_dir,
+        process_factory=factory,
+        resolver=lambda host, port: {
+            "one.example.com": "198.51.100.1",
+            "two.example.com": "198.51.100.2",
+        }[host],
+        binary_validator=lambda path: None,
+        state_store=state_store or FakeStateStore(),
+    )
+    return runtime, processes
+
+
+def test_connect_verify_disconnect_orders_guard_and_cleanup(tmp_path):
+    network = FakeNetwork()
+    runtime, processes = make_runtime(network, tmp_path)
+    route = parse_link(ROUTE_ONE)
+    assert route is not None
+
+    runtime.connect(route)
+    verified = runtime.verify()
+    disconnected = runtime.disconnect()
+
+    assert verified["external_ip"] == "203.0.113.20"
+    assert disconnected["state"] == "disconnected"
+    assert network.calls[:3] == [
+        ("check",),
+        ("guard-on", "xrayebator0", 22610),
+        ("dns-on", "xrayebator0"),
+    ]
+    assert network.calls[-1] == ("guard-off",)
+    assert processes[0].stop_calls == 1
+
+
+def test_failed_switch_keeps_guard_for_controller_rollback(tmp_path):
+    network = FakeNetwork()
+    runtime, _ = make_runtime(
+        network,
+        tmp_path,
+        fail_addresses={"1"},
+    )
+    first = parse_link(ROUTE_ONE)
+    second = parse_link(ROUTE_TWO)
+    assert first is not None and second is not None
+    runtime.connect(first)
+
+    with pytest.raises(TunRuntimeError, match="kill switch закрыт"):
+        runtime.switch(second)
+
+    assert runtime.status()["state"] == "guarded_error"
+    assert network.guarded is True
+
+    recovered = runtime.switch(first)
+    assert recovered["state"] == "connected"
+    assert network.guarded is True
+
+
+def test_dead_xray_transitions_to_closed_guard_state(tmp_path):
+    network = FakeNetwork()
+    runtime, processes = make_runtime(network, tmp_path)
+    route = parse_link(ROUTE_ONE)
+    assert route is not None
+    runtime.connect(route)
+    processes[0].running = False
+
+    status = runtime.status()
+
+    assert status["state"] == "guarded_error"
+    assert "kill switch" in status["error"]
+    assert network.guarded is True
+
+
+def test_recovery_uses_persisted_ip_without_dns_resolution(tmp_path):
+    route = parse_link(ROUTE_ONE)
+    assert route is not None
+    network = FakeNetwork()
+    network.guarded = True
+    state_store = FakeStateStore(StoredRoute(route, "198.51.100.1"))
+    processes = []
+
+    def factory(binary, config_path, stderr_path):
+        process = FakeProcess("recovered")
+        processes.append(process)
+        return process
+
+    runtime = TunRuntime(
+        network=network,
+        runtime_dir=tmp_path,
+        process_factory=factory,
+        resolver=lambda host, port: (_ for _ in ()).throw(
+            AssertionError("recovery must not use DNS")
+        ),
+        binary_validator=lambda path: None,
+        state_store=state_store,
+    )
+
+    result = runtime.recover()
+
+    assert result["state"] == "connected"
+    assert processes[0].running is True

--- a/gui/tests/test_tun_runtime.py
+++ b/gui/tests/test_tun_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from xrayebator_gui.core.subscription import parse_link
+from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.helper.runtime import TunRuntime, TunRuntimeError
 from xrayebator_gui.helper.state import StoredRoute
 
@@ -72,9 +73,9 @@ class FakeStateStore:
         self.saved = []
         self.remove_calls = 0
 
-    def save(self, route, address):
-        self.saved.append((route, address))
-        self.stored = StoredRoute(route, address)
+    def save(self, route, address, routing_profile):
+        self.saved.append((route, address, routing_profile))
+        self.stored = StoredRoute(route, address, routing_profile)
 
     def load(self):
         return self.stored
@@ -121,7 +122,7 @@ def test_connect_verify_disconnect_orders_guard_and_cleanup(tmp_path):
     route = parse_link(ROUTE_ONE)
     assert route is not None
 
-    runtime.connect(route)
+    runtime.connect(route, RoutingProfile.FULL)
     verified = runtime.verify()
     disconnected = runtime.disconnect()
 
@@ -146,15 +147,15 @@ def test_failed_switch_keeps_guard_for_controller_rollback(tmp_path):
     first = parse_link(ROUTE_ONE)
     second = parse_link(ROUTE_TWO)
     assert first is not None and second is not None
-    runtime.connect(first)
+    runtime.connect(first, RoutingProfile.FULL)
 
     with pytest.raises(TunRuntimeError, match="kill switch закрыт"):
-        runtime.switch(second)
+        runtime.switch(second, RoutingProfile.SMART_RU)
 
     assert runtime.status()["state"] == "guarded_error"
     assert network.guarded is True
 
-    recovered = runtime.switch(first)
+    recovered = runtime.switch(first, RoutingProfile.FULL)
     assert recovered["state"] == "connected"
     assert network.guarded is True
 
@@ -164,7 +165,7 @@ def test_dead_xray_transitions_to_closed_guard_state(tmp_path):
     runtime, processes = make_runtime(network, tmp_path)
     route = parse_link(ROUTE_ONE)
     assert route is not None
-    runtime.connect(route)
+    runtime.connect(route, RoutingProfile.FULL)
     processes[0].running = False
 
     status = runtime.status()
@@ -179,7 +180,13 @@ def test_recovery_uses_persisted_ip_without_dns_resolution(tmp_path):
     assert route is not None
     network = FakeNetwork()
     network.guarded = True
-    state_store = FakeStateStore(StoredRoute(route, "198.51.100.1"))
+    state_store = FakeStateStore(
+        StoredRoute(
+            route,
+            "198.51.100.1",
+            RoutingProfile.SMART_RU,
+        )
+    )
     processes = []
 
     def factory(binary, config_path, stderr_path):
@@ -202,3 +209,16 @@ def test_recovery_uses_persisted_ip_without_dns_resolution(tmp_path):
 
     assert result["state"] == "connected"
     assert processes[0].running is True
+
+
+def test_reconnect_same_target_adopts_existing_tun_without_restart(tmp_path):
+    network = FakeNetwork()
+    runtime, processes = make_runtime(network, tmp_path)
+    route = parse_link(ROUTE_ONE)
+    assert route is not None
+    runtime.connect(route, RoutingProfile.SMART_RU)
+
+    result = runtime.connect(route, RoutingProfile.SMART_RU)
+
+    assert result["state"] == "connected"
+    assert len(processes) == 1

--- a/gui/tests/test_tun_runtime.py
+++ b/gui/tests/test_tun_runtime.py
@@ -33,6 +33,9 @@ class FakeNetwork:
         self.guarded = True
         self.calls.append(("guard-on", interface, mark))
 
+    def validate_guard(self, interface, mark):
+        self.calls.append(("guard-check", interface, mark))
+
     def disable_guard(self):
         self.guarded = False
         self.calls.append(("guard-off",))
@@ -222,3 +225,20 @@ def test_reconnect_same_target_adopts_existing_tun_without_restart(tmp_path):
 
     assert result["state"] == "connected"
     assert len(processes) == 1
+
+
+def test_selftest_validates_dependencies_binary_and_nft_rules(tmp_path):
+    network = FakeNetwork()
+    validated = []
+    runtime = TunRuntime(
+        network=network,
+        runtime_dir=tmp_path,
+        binary_validator=lambda path: validated.append(path),
+        state_store=FakeStateStore(),
+    )
+
+    result = runtime.selftest()
+
+    assert result["state"] == "disconnected"
+    assert validated
+    assert ("guard-check", "xrayebator0", 22610) in network.calls

--- a/gui/tests/test_xray.py
+++ b/gui/tests/test_xray.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.core.subscription import VlessLink
 from xrayebator_gui.core.xray import (
     XrayError,
@@ -86,6 +87,22 @@ def test_tun_can_expose_local_proxies_for_mixed_mode():
         "socks",
         "http",
     ]
+
+
+def test_smart_ru_routing_orders_block_before_direct():
+    config = build_tun_client_config(
+        link(),
+        system="Linux",
+        routing_profile=RoutingProfile.SMART_RU,
+    )
+    rules = config["routing"]["rules"]
+
+    assert rules[0]["outboundTag"] == "block"
+    assert "geosite:category-ads-all" in rules[0]["domain"]
+    assert rules[1]["outboundTag"] == "direct"
+    assert "geoip:private" in rules[1]["ip"]
+    assert "geosite:category-ru" in rules[2]["domain"]
+    assert "geoip:ru" in rules[3]["ip"]
 
 
 def test_post_quantum_encryption_omits_incompatible_vision_flow():

--- a/gui/tests/test_xray.py
+++ b/gui/tests/test_xray.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from xrayebator_gui.core.subscription import VlessLink
+from xrayebator_gui.core.xray import (
+    XrayError,
+    _parse_dgst,
+    build_client_config,
+    build_tun_client_config,
+)
+
+
+def link(*, encryption: str = "none") -> VlessLink:
+    return VlessLink(
+        raw="vless://uuid@vpn.example.com:443",
+        address="vpn.example.com",
+        port=443,
+        uuid="uuid",
+        network="tcp",
+        security="reality",
+        sni="www.example.com",
+        fingerprint="chrome",
+        public_key="public",
+        short_id="0123456789abcdef",
+        flow="xtls-rprx-vision",
+        encryption=encryption,
+        remark="Vision",
+    )
+
+
+def test_system_proxy_config_has_local_inbounds():
+    config = build_client_config(link())
+
+    assert [inbound["protocol"] for inbound in config["inbounds"]] == [
+        "socks",
+        "http",
+    ]
+    assert config["outbounds"][0]["tag"] == "proxy"
+
+
+def test_linux_tun_config_uses_auto_routes_and_loop_prevention():
+    config = build_tun_client_config(link(), system="Linux")
+    inbound = config["inbounds"][0]
+    settings = inbound["settings"]
+
+    assert inbound["protocol"] == "tun"
+    assert settings["name"] == "xrayebator0"
+    assert settings["autoSystemRoutingTable"] == ["0.0.0.0/0", "::/0"]
+    assert settings["autoOutboundsInterface"] == "auto"
+    assert "dns" not in settings
+
+
+def test_windows_tun_config_includes_wintun_description_and_dns():
+    settings = build_tun_client_config(
+        link(), system="Windows", ipv6=False
+    )["inbounds"][0]["settings"]
+
+    assert settings["name"] == "xrayebator"
+    assert settings["desc"] == "Xrayebator"
+    assert settings["dns"] == ["1.1.1.1", "8.8.8.8"]
+    assert settings["gateway"] == ["10.254.0.1/30"]
+    assert settings["autoSystemRoutingTable"] == ["0.0.0.0/0"]
+
+
+def test_darwin_leaves_utun_name_selection_to_xray():
+    settings = build_tun_client_config(link(), system="Darwin")["inbounds"][0][
+        "settings"
+    ]
+
+    assert "name" not in settings
+    assert "dns" not in settings
+
+
+def test_tun_can_expose_local_proxies_for_mixed_mode():
+    config = build_tun_client_config(
+        link(), system="Linux", include_local_proxies=True
+    )
+
+    assert [inbound["protocol"] for inbound in config["inbounds"]] == [
+        "tun",
+        "socks",
+        "http",
+    ]
+
+
+def test_post_quantum_encryption_omits_incompatible_vision_flow():
+    config = build_tun_client_config(
+        link(encryption="mlkem768x25519plus.native"),
+        system="Linux",
+    )
+    user = config["outbounds"][0]["settings"]["vnext"][0]["users"][0]
+
+    assert user["encryption"] == "mlkem768x25519plus.native"
+    assert "flow" not in user
+
+
+@pytest.mark.parametrize("mtu", [0, 1279, 9001])
+def test_tun_rejects_unsafe_mtu(mtu):
+    with pytest.raises(XrayError, match="MTU"):
+        build_tun_client_config(link(), system="Linux", mtu=mtu)
+
+
+def test_tun_rejects_unknown_platform():
+    with pytest.raises(XrayError, match="не поддерживается"):
+        build_tun_client_config(link(), system="Plan9")
+
+
+def test_parse_dgst_accepts_release_asset_line():
+    digest = "a" * 64
+    text = f"{digest}  Xray-linux-64.zip\n"
+
+    assert _parse_dgst(text, "Xray-linux-64.zip") == digest

--- a/gui/tests/test_xray.py
+++ b/gui/tests/test_xray.py
@@ -40,7 +40,11 @@ def test_system_proxy_config_has_local_inbounds():
 
 
 def test_linux_tun_config_uses_auto_routes_and_loop_prevention():
-    config = build_tun_client_config(link(), system="Linux")
+    config = build_tun_client_config(
+        link(),
+        system="Linux",
+        outbound_mark=0x5852,
+    )
     inbound = config["inbounds"][0]
     settings = inbound["settings"]
 
@@ -49,12 +53,14 @@ def test_linux_tun_config_uses_auto_routes_and_loop_prevention():
     assert settings["autoSystemRoutingTable"] == ["0.0.0.0/0", "::/0"]
     assert settings["autoOutboundsInterface"] == "auto"
     assert "dns" not in settings
+    assert config["outbounds"][0]["streamSettings"]["sockopt"]["mark"] == 0x5852
+    assert config["outbounds"][1]["streamSettings"]["sockopt"]["mark"] == 0x5852
 
 
 def test_windows_tun_config_includes_wintun_description_and_dns():
-    settings = build_tun_client_config(
-        link(), system="Windows", ipv6=False
-    )["inbounds"][0]["settings"]
+    settings = build_tun_client_config(link(), system="Windows", ipv6=False)[
+        "inbounds"
+    ][0]["settings"]
 
     assert settings["name"] == "xrayebator"
     assert settings["desc"] == "Xrayebator"
@@ -73,9 +79,7 @@ def test_darwin_leaves_utun_name_selection_to_xray():
 
 
 def test_tun_can_expose_local_proxies_for_mixed_mode():
-    config = build_tun_client_config(
-        link(), system="Linux", include_local_proxies=True
-    )
+    config = build_tun_client_config(link(), system="Linux", include_local_proxies=True)
 
     assert [inbound["protocol"] for inbound in config["inbounds"]] == [
         "tun",
@@ -106,8 +110,21 @@ def test_tun_rejects_unknown_platform():
         build_tun_client_config(link(), system="Plan9")
 
 
+@pytest.mark.parametrize("mark", [0, -1, 0x1_0000_0000])
+def test_tun_rejects_invalid_outbound_mark(mark):
+    with pytest.raises(XrayError, match="метка"):
+        build_tun_client_config(link(), system="Linux", outbound_mark=mark)
+
+
 def test_parse_dgst_accepts_release_asset_line():
     digest = "a" * 64
     text = f"{digest}  Xray-linux-64.zip\n"
+
+    assert _parse_dgst(text, "Xray-linux-64.zip") == digest
+
+
+def test_parse_dgst_accepts_actual_xray_release_format():
+    digest = "b" * 64
+    text = f"MD5= {'a' * 32}\nSHA2-256= {digest}\n"
 
     assert _parse_dgst(text, "Xray-linux-64.zip") == digest

--- a/gui/tests/test_xray.py
+++ b/gui/tests/test_xray.py
@@ -6,6 +6,7 @@ from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.core.subscription import VlessLink
 from xrayebator_gui.core.xray import (
     XrayError,
+    XrayProcess,
     _parse_dgst,
     build_client_config,
     build_tun_client_config,
@@ -145,3 +146,38 @@ def test_parse_dgst_accepts_actual_xray_release_format():
     text = f"MD5= {'a' * 32}\nSHA2-256= {digest}\n"
 
     assert _parse_dgst(text, "Xray-linux-64.zip") == digest
+
+
+def test_xray_runtime_files_are_owner_only(monkeypatch, tmp_path):
+    binary = tmp_path / "xray"
+    binary.write_bytes(b"binary")
+    binary.chmod(0o755)
+
+    class FakePopen:
+        def __init__(self, *args, **kwargs):
+            self.returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def terminate(self):
+            self.returncode = 0
+
+        def wait(self, timeout):
+            return self.returncode
+
+    monkeypatch.setattr("xrayebator_gui.core.xray.subprocess.Popen", FakePopen)
+    monkeypatch.setattr("xrayebator_gui.core.xray.time.sleep", lambda _: None)
+    config_path = tmp_path / "runtime" / "config.json"
+    log_path = tmp_path / "runtime" / "xray.log"
+    process = XrayProcess(
+        binary,
+        config_path=config_path,
+        stderr_path=log_path,
+    )
+
+    process.start(build_client_config(link()))
+    process.stop()
+
+    assert config_path.stat().st_mode & 0o777 == 0o600
+    assert log_path.stat().st_mode & 0o777 == 0o600

--- a/gui/tests/test_xray_binary_integration.py
+++ b/gui/tests/test_xray_binary_integration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from xrayebator_gui.core.subscription import parse_link
+from xrayebator_gui.core.xray import build_tun_client_config
+
+
+def test_real_xray_accepts_generated_tun_config(tmp_path):
+    binary = os.environ.get("XRAY_TEST_BINARY")
+    if not binary:
+        pytest.skip("set XRAY_TEST_BINARY to run real Xray config validation")
+    route = parse_link(
+        "vless://11111111-1111-1111-1111-111111111111@198.51.100.1:443"
+        "?type=tcp&security=reality&sni=www.example.com&fp=chrome"
+        "&pbk=O0rrwmWNVNHiHzBuTpIA_jbhZy6uZT7Q4u-INKcUuWc"
+        "&sid=0123456789abcdef&flow=xtls-rprx-vision#Vision"
+    )
+    assert route is not None
+    config = build_tun_client_config(
+        route,
+        system="Linux",
+        outbound_mark=0x5852,
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    result = subprocess.run(
+        [binary, "run", "-test", "-c", str(config_path)],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/gui/tests/test_xray_binary_integration.py
+++ b/gui/tests/test_xray_binary_integration.py
@@ -7,10 +7,15 @@ import subprocess
 import pytest
 
 from xrayebator_gui.core.subscription import parse_link
+from xrayebator_gui.core.routing import RoutingProfile
 from xrayebator_gui.core.xray import build_tun_client_config
 
 
-def test_real_xray_accepts_generated_tun_config(tmp_path):
+@pytest.mark.parametrize(
+    "profile",
+    [RoutingProfile.FULL, RoutingProfile.SMART_RU],
+)
+def test_real_xray_accepts_generated_tun_config(tmp_path, profile):
     binary = os.environ.get("XRAY_TEST_BINARY")
     if not binary:
         pytest.skip("set XRAY_TEST_BINARY to run real Xray config validation")
@@ -25,6 +30,7 @@ def test_real_xray_accepts_generated_tun_config(tmp_path):
         route,
         system="Linux",
         outbound_mark=0x5852,
+        routing_profile=profile,
     )
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps(config), encoding="utf-8")

--- a/gui/xrayebator_gui/__init__.py
+++ b/gui/xrayebator_gui/__init__.py
@@ -1,0 +1,3 @@
+"""Xrayebator GUI — desktop-обёртка для развёртывания Xray VLESS Reality на VPS."""
+
+__version__ = "0.1.0"

--- a/gui/xrayebator_gui/__init__.py
+++ b/gui/xrayebator_gui/__init__.py
@@ -1,3 +1,3 @@
 """Xrayebator GUI — desktop-обёртка для развёртывания Xray VLESS Reality на VPS."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/gui/xrayebator_gui/__main__.py
+++ b/gui/xrayebator_gui/__main__.py
@@ -1,0 +1,3 @@
+from .app import main
+
+raise SystemExit(main())

--- a/gui/xrayebator_gui/app.py
+++ b/gui/xrayebator_gui/app.py
@@ -1,0 +1,65 @@
+"""Точка входа: QApplication, тёмная тема, главное окно, tray."""
+
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtGui import QColor, QIcon, QPalette, QPixmap, QPainter, QBrush
+from PySide6.QtWidgets import QApplication
+
+from .ui.main_window import MainWindow
+
+APP_NAME = "Xrayebator GUI"
+
+
+def _apply_dark_palette(app: QApplication) -> None:
+    """Простая тёмная тема через QPalette."""
+    p = QPalette()
+    p.setColor(QPalette.ColorRole.Window, QColor(45, 45, 48))
+    p.setColor(QPalette.ColorRole.WindowText, QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.Base, QColor(30, 30, 32))
+    p.setColor(QPalette.ColorRole.AlternateBase, QColor(45, 45, 48))
+    p.setColor(QPalette.ColorRole.ToolTipBase, QColor(30, 30, 32))
+    p.setColor(QPalette.ColorRole.ToolTipText, QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.Text, QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.Button, QColor(55, 55, 60))
+    p.setColor(QPalette.ColorRole.ButtonText, QColor(220, 220, 220))
+    p.setColor(QPalette.ColorRole.Highlight, QColor(42, 130, 218))
+    p.setColor(QPalette.ColorRole.HighlightedText, QColor(0, 0, 0))
+    p.setColor(QPalette.ColorRole.PlaceholderText, QColor(130, 130, 130))
+    p.setColor(QPalette.ColorRole.Link, QColor(42, 130, 218))
+    app.setPalette(p)
+
+
+def make_app_icon(size: int = 64) -> QIcon:
+    """Нарисовать простую иконку-круг (для tray и окна)."""
+    pm = QPixmap(size, size)
+    pm.fill(QColor(0, 0, 0, 0))
+    painter = QPainter(pm)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+    painter.setBrush(QBrush(QColor(42, 130, 218)))
+    painter.setPen(QColor(0, 0, 0, 0))
+    painter.drawEllipse(4, 4, size - 8, size - 8)
+    painter.setPen(QColor(255, 255, 255))
+    font = painter.font()
+    font.setBold(True)
+    font.setPixelSize(size // 2)
+    painter.setFont(font)
+    painter.drawText(pm.rect(), 0x0084, "X")  # Qt.AlignmentFlag.AlignCenter
+    painter.end()
+    return QIcon(pm)
+
+
+def main() -> int:
+    app = QApplication(sys.argv)
+    app.setApplicationName(APP_NAME)
+    app.setOrganizationName("xrayebator")
+    # Не выходить из приложения при закрытии окна — живём в tray.
+    app.setQuitOnLastWindowClosed(False)
+    _apply_dark_palette(app)
+    icon = make_app_icon()
+    app.setWindowIcon(icon)
+
+    window = MainWindow(icon=icon)
+    window.show()
+    return app.exec()

--- a/gui/xrayebator_gui/app.py
+++ b/gui/xrayebator_gui/app.py
@@ -61,5 +61,8 @@ def main() -> int:
     app.setWindowIcon(icon)
 
     window = MainWindow(icon=icon)
+    if "--self-test" in sys.argv[1:]:
+        window.close()
+        return 0
     window.show()
     return app.exec()

--- a/gui/xrayebator_gui/core/connection.py
+++ b/gui/xrayebator_gui/core/connection.py
@@ -114,7 +114,9 @@ class ConnectionController:
             self._transition(ConnectionState.VERIFYING)
             external_ip = self._backend.verify()
             if not external_ip:
-                raise ConnectionError("Туннель запущен, но проверка внешнего IP не прошла")
+                raise ConnectionError(
+                    "Туннель запущен, но проверка внешнего IP не прошла"
+                )
         except Exception as exc:
             self._stop_after_failure()
             self._transition(ConnectionState.ERROR, error=str(exc), external_ip=None)
@@ -151,7 +153,9 @@ class ConnectionController:
 
     def switch_route(self, route: VlessLink) -> ConnectionSnapshot:
         if self._snapshot.state != ConnectionState.CONNECTED:
-            raise InvalidTransition("Маршрут можно менять только при активном соединении")
+            raise InvalidTransition(
+                "Маршрут можно менять только при активном соединении"
+            )
         previous = self._snapshot.route
         mode = self._snapshot.mode
         if previous is None or mode is None:

--- a/gui/xrayebator_gui/core/connection.py
+++ b/gui/xrayebator_gui/core/connection.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Callable, Optional, Protocol
 
+from .routing import RoutingProfile
 from .subscription import VlessLink
 
 
@@ -31,6 +32,7 @@ class ConnectionSnapshot:
     state: ConnectionState = ConnectionState.DISCONNECTED
     mode: Optional[ConnectionMode] = None
     route: Optional[VlessLink] = None
+    routing_profile: Optional[RoutingProfile] = None
     external_ip: Optional[str] = None
     error: Optional[str] = None
 
@@ -50,13 +52,28 @@ class RouteSwitchError(ConnectionError):
 class TunnelBackend(Protocol):
     """Operations implemented by system-proxy and privileged TUN backends."""
 
-    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None: ...
+    def prepare(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None: ...
 
-    def start(self, route: VlessLink, mode: ConnectionMode) -> None: ...
+    def start(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None: ...
 
     def verify(self) -> Optional[str]: ...
 
-    def replace(self, route: VlessLink, mode: ConnectionMode) -> None: ...
+    def replace(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None: ...
 
     def stop(self) -> None: ...
 
@@ -91,7 +108,12 @@ class ConnectionController:
         for observer in tuple(self._observers):
             observer(self._snapshot)
 
-    def connect(self, route: VlessLink, mode: ConnectionMode) -> ConnectionSnapshot:
+    def connect(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile = RoutingProfile.FULL,
+    ) -> ConnectionSnapshot:
         if self._snapshot.state not in {
             ConnectionState.DISCONNECTED,
             ConnectionState.ERROR,
@@ -104,13 +126,14 @@ class ConnectionController:
             ConnectionState.PREPARING,
             mode=mode,
             route=route,
+            routing_profile=routing_profile,
             external_ip=None,
             error=None,
         )
         try:
-            self._backend.prepare(route, mode)
+            self._backend.prepare(route, mode, routing_profile)
             self._transition(ConnectionState.CONNECTING)
-            self._backend.start(route, mode)
+            self._backend.start(route, mode, routing_profile)
             self._transition(ConnectionState.VERIFYING)
             external_ip = self._backend.verify()
             if not external_ip:
@@ -146,6 +169,7 @@ class ConnectionController:
             ConnectionState.DISCONNECTED,
             mode=None,
             route=None,
+            routing_profile=None,
             external_ip=None,
             error=None,
         )
@@ -158,19 +182,52 @@ class ConnectionController:
             )
         previous = self._snapshot.route
         mode = self._snapshot.mode
-        if previous is None or mode is None:
-            raise ConnectionError("Активное соединение не содержит маршрут или режим")
+        routing_profile = self._snapshot.routing_profile
+        if previous is None or mode is None or routing_profile is None:
+            raise ConnectionError(
+                "Активное соединение не содержит маршрут, профиль или режим"
+            )
         if route.raw == previous.raw:
             return self._snapshot
+        return self._switch_target(route, routing_profile)
+
+    def switch_profile(
+        self,
+        routing_profile: RoutingProfile,
+    ) -> ConnectionSnapshot:
+        if self._snapshot.state != ConnectionState.CONNECTED:
+            raise InvalidTransition(
+                "Routing profile можно менять только при активном соединении"
+            )
+        route = self._snapshot.route
+        if route is None:
+            raise ConnectionError("Активное соединение не содержит маршрут")
+        if routing_profile == self._snapshot.routing_profile:
+            return self._snapshot
+        return self._switch_target(route, routing_profile)
+
+    def _switch_target(
+        self,
+        route: VlessLink,
+        routing_profile: RoutingProfile,
+    ) -> ConnectionSnapshot:
+        previous = self._snapshot.route
+        previous_profile = self._snapshot.routing_profile
+        mode = self._snapshot.mode
+        if previous is None or previous_profile is None or mode is None:
+            raise ConnectionError(
+                "Активное соединение не содержит маршрут, профиль или режим"
+            )
 
         self._transition(
             ConnectionState.SWITCHING,
             route=route,
+            routing_profile=routing_profile,
             external_ip=None,
             error=None,
         )
         try:
-            self._backend.replace(route, mode)
+            self._backend.replace(route, mode, routing_profile)
             external_ip = self._backend.verify()
             if not external_ip:
                 raise ConnectionError("Новый маршрут не прошёл проверку")
@@ -178,10 +235,11 @@ class ConnectionController:
             self._transition(
                 ConnectionState.RECOVERING,
                 route=previous,
+                routing_profile=previous_profile,
                 error=str(candidate_exc),
             )
             try:
-                self._backend.replace(previous, mode)
+                self._backend.replace(previous, mode, previous_profile)
                 external_ip = self._backend.verify()
                 if not external_ip:
                     raise ConnectionError("Предыдущий маршрут не прошёл проверку")
@@ -194,18 +252,18 @@ class ConnectionController:
                 self._transition(
                     ConnectionState.ERROR,
                     route=None,
+                    routing_profile=None,
                     external_ip=None,
                     error=message,
                 )
                 raise RouteSwitchError(message) from rollback_exc
 
-            message = (
-                f"Маршрут {route.label} не прошёл проверку; "
-                f"восстановлен {previous.label}: {candidate_exc}"
-            )
+            message = "Переключение не прошло проверку; восстановлены "
+            message += f"{previous.label}, {previous_profile.label}: {candidate_exc}"
             self._transition(
                 ConnectionState.CONNECTED,
                 route=previous,
+                routing_profile=previous_profile,
                 external_ip=external_ip,
                 error=message,
             )
@@ -214,6 +272,7 @@ class ConnectionController:
         self._transition(
             ConnectionState.CONNECTED,
             route=route,
+            routing_profile=routing_profile,
             external_ip=external_ip,
             error=None,
         )

--- a/gui/xrayebator_gui/core/connection.py
+++ b/gui/xrayebator_gui/core/connection.py
@@ -1,0 +1,222 @@
+"""Connection lifecycle independent from Qt and concrete tunnel backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Callable, Optional, Protocol
+
+from .subscription import VlessLink
+
+
+class ConnectionState(str, Enum):
+    DISCONNECTED = "disconnected"
+    PREPARING = "preparing"
+    CONNECTING = "connecting"
+    VERIFYING = "verifying"
+    CONNECTED = "connected"
+    SWITCHING = "switching"
+    DISCONNECTING = "disconnecting"
+    RECOVERING = "recovering"
+    ERROR = "error"
+
+
+class ConnectionMode(str, Enum):
+    SYSTEM_PROXY = "system_proxy"
+    TUN = "tun"
+
+
+@dataclass(frozen=True)
+class ConnectionSnapshot:
+    state: ConnectionState = ConnectionState.DISCONNECTED
+    mode: Optional[ConnectionMode] = None
+    route: Optional[VlessLink] = None
+    external_ip: Optional[str] = None
+    error: Optional[str] = None
+
+
+class ConnectionError(RuntimeError):
+    """Connection lifecycle operation failed."""
+
+
+class InvalidTransition(ConnectionError):
+    """Operation is not allowed from the current state."""
+
+
+class RouteSwitchError(ConnectionError):
+    """Candidate route failed; the previous route may have been restored."""
+
+
+class TunnelBackend(Protocol):
+    """Operations implemented by system-proxy and privileged TUN backends."""
+
+    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None: ...
+
+    def start(self, route: VlessLink, mode: ConnectionMode) -> None: ...
+
+    def verify(self) -> Optional[str]: ...
+
+    def replace(self, route: VlessLink, mode: ConnectionMode) -> None: ...
+
+    def stop(self) -> None: ...
+
+
+Observer = Callable[[ConnectionSnapshot], None]
+
+
+class ConnectionController:
+    """Synchronous state machine; UI code runs operations in a worker thread."""
+
+    def __init__(self, backend: TunnelBackend):
+        self._backend = backend
+        self._snapshot = ConnectionSnapshot()
+        self._observers: list[Observer] = []
+
+    @property
+    def snapshot(self) -> ConnectionSnapshot:
+        return self._snapshot
+
+    def subscribe(self, observer: Observer) -> Callable[[], None]:
+        self._observers.append(observer)
+        observer(self._snapshot)
+
+        def unsubscribe() -> None:
+            if observer in self._observers:
+                self._observers.remove(observer)
+
+        return unsubscribe
+
+    def _transition(self, state: ConnectionState, **changes) -> None:
+        self._snapshot = replace(self._snapshot, state=state, **changes)
+        for observer in tuple(self._observers):
+            observer(self._snapshot)
+
+    def connect(self, route: VlessLink, mode: ConnectionMode) -> ConnectionSnapshot:
+        if self._snapshot.state not in {
+            ConnectionState.DISCONNECTED,
+            ConnectionState.ERROR,
+        }:
+            raise InvalidTransition(
+                f"Нельзя подключиться из состояния {self._snapshot.state.value}"
+            )
+
+        self._transition(
+            ConnectionState.PREPARING,
+            mode=mode,
+            route=route,
+            external_ip=None,
+            error=None,
+        )
+        try:
+            self._backend.prepare(route, mode)
+            self._transition(ConnectionState.CONNECTING)
+            self._backend.start(route, mode)
+            self._transition(ConnectionState.VERIFYING)
+            external_ip = self._backend.verify()
+            if not external_ip:
+                raise ConnectionError("Туннель запущен, но проверка внешнего IP не прошла")
+        except Exception as exc:
+            self._stop_after_failure()
+            self._transition(ConnectionState.ERROR, error=str(exc), external_ip=None)
+            raise ConnectionError(str(exc)) from exc
+
+        self._transition(
+            ConnectionState.CONNECTED,
+            external_ip=external_ip,
+            error=None,
+        )
+        return self._snapshot
+
+    def disconnect(self) -> ConnectionSnapshot:
+        if self._snapshot.state == ConnectionState.DISCONNECTED:
+            return self._snapshot
+        if self._snapshot.state == ConnectionState.DISCONNECTING:
+            raise InvalidTransition("Отключение уже выполняется")
+
+        self._transition(ConnectionState.DISCONNECTING, error=None)
+        try:
+            self._backend.stop()
+        except Exception as exc:
+            self._transition(ConnectionState.ERROR, error=str(exc))
+            raise ConnectionError(str(exc)) from exc
+
+        self._transition(
+            ConnectionState.DISCONNECTED,
+            mode=None,
+            route=None,
+            external_ip=None,
+            error=None,
+        )
+        return self._snapshot
+
+    def switch_route(self, route: VlessLink) -> ConnectionSnapshot:
+        if self._snapshot.state != ConnectionState.CONNECTED:
+            raise InvalidTransition("Маршрут можно менять только при активном соединении")
+        previous = self._snapshot.route
+        mode = self._snapshot.mode
+        if previous is None or mode is None:
+            raise ConnectionError("Активное соединение не содержит маршрут или режим")
+        if route.raw == previous.raw:
+            return self._snapshot
+
+        self._transition(
+            ConnectionState.SWITCHING,
+            route=route,
+            external_ip=None,
+            error=None,
+        )
+        try:
+            self._backend.replace(route, mode)
+            external_ip = self._backend.verify()
+            if not external_ip:
+                raise ConnectionError("Новый маршрут не прошёл проверку")
+        except Exception as candidate_exc:
+            self._transition(
+                ConnectionState.RECOVERING,
+                route=previous,
+                error=str(candidate_exc),
+            )
+            try:
+                self._backend.replace(previous, mode)
+                external_ip = self._backend.verify()
+                if not external_ip:
+                    raise ConnectionError("Предыдущий маршрут не прошёл проверку")
+            except Exception as rollback_exc:
+                self._stop_after_failure()
+                message = (
+                    f"Новый маршрут не запустился ({candidate_exc}); "
+                    f"откат также не удался ({rollback_exc})"
+                )
+                self._transition(
+                    ConnectionState.ERROR,
+                    route=None,
+                    external_ip=None,
+                    error=message,
+                )
+                raise RouteSwitchError(message) from rollback_exc
+
+            message = (
+                f"Маршрут {route.label} не прошёл проверку; "
+                f"восстановлен {previous.label}: {candidate_exc}"
+            )
+            self._transition(
+                ConnectionState.CONNECTED,
+                route=previous,
+                external_ip=external_ip,
+                error=message,
+            )
+            raise RouteSwitchError(message) from candidate_exc
+
+        self._transition(
+            ConnectionState.CONNECTED,
+            route=route,
+            external_ip=external_ip,
+            error=None,
+        )
+        return self._snapshot
+
+    def _stop_after_failure(self) -> None:
+        try:
+            self._backend.stop()
+        except Exception:
+            pass

--- a/gui/xrayebator_gui/core/deploy.py
+++ b/gui/xrayebator_gui/core/deploy.py
@@ -1,0 +1,317 @@
+"""Оркестратор развёртывания Xrayebator на VPS.
+
+Deployer — чистый Python (тестируется без Qt), DeployThread — тонкая
+Qt-обёртка с сигналами для UI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from pathlib import Path
+from typing import Callable, Optional, Protocol
+
+# Корень репозитория: gui/xrayebator_gui/core/deploy.py -> ../../../
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Поддерживаемые ОС: {id: {версии}}
+SUPPORTED_OS = {
+    "debian": {"12", "13"},
+    "ubuntu": {"22.04", "24.04"},
+}
+
+STEPS = [
+    "Подключение по SSH",
+    "Проверка операционной системы",
+    "Загрузка install.sh и xrayebator",
+    "Установка Xrayebator (install.sh)",
+    "Установка локальной версии xrayebator",
+    "Создание профиля и подписки (quickstart)",
+    "Сохранение сервера",
+]
+
+
+class DeployError(Exception):
+    """Ошибка развёртывания с человекочитаемым сообщением."""
+
+
+class UnsupportedOSError(DeployError):
+    """ОС сервера не поддерживается."""
+
+
+class SSHLike(Protocol):
+    """Минимальный интерфейс SSH-клиента, нужный Deployer'у."""
+
+    def connect(
+        self,
+        host: str,
+        port: int = 22,
+        user: str = "root",
+        password: Optional[str] = None,
+        key_path: Optional[str] = None,
+        sudo_password: Optional[str] = None,
+    ) -> None: ...
+
+    def run_streaming(
+        self,
+        command: str,
+        on_line: Optional[Callable[[str], None]] = None,
+        timeout: Optional[float] = 600.0,
+        *,
+        privileged: bool = True,
+    ) -> int: ...
+
+    def upload(self, local_path: str | Path, remote_path: str) -> None: ...
+
+    def close(self) -> None: ...
+
+
+def parse_os_release(text: str) -> tuple[str, str]:
+    """Извлечь (ID, VERSION_ID) из содержимого /etc/os-release."""
+    os_id = version = ""
+    for line in text.splitlines():
+        m = re.match(r"^([A-Z_]+)=(.*)$", line.strip())
+        if not m:
+            continue
+        key, val = m.group(1), m.group(2).strip().strip('"')
+        if key == "ID":
+            os_id = val.lower()
+        elif key == "VERSION_ID":
+            version = val
+    return os_id, version
+
+
+def check_os_supported(text: str) -> tuple[str, str]:
+    """Проверить ОС по /etc/os-release; бросить UnsupportedOSError."""
+    os_id, version = parse_os_release(text)
+    if os_id not in SUPPORTED_OS or version not in SUPPORTED_OS[os_id]:
+        supported = ", ".join(
+            f"{k} {'/'.join(sorted(v))}" for k, v in SUPPORTED_OS.items()
+        )
+        raise UnsupportedOSError(
+            f"Неподдерживаемая ОС сервера: {os_id or '?'} {version or '?'}.\n"
+            f"Поддерживаются: {supported}"
+        )
+    return os_id, version
+
+
+class Deployer:
+    """Чистый оркестратор развёртывания (без Qt)."""
+
+    def __init__(
+        self,
+        ssh_client: SSHLike,
+        *,
+        host: str,
+        email: str,
+        port: int = 22,
+        user: str = "root",
+        password: Optional[str] = None,
+        key_path: Optional[str] = None,
+        sudo_password: Optional[str] = None,
+        repo_root: Path = REPO_ROOT,
+        on_step: Optional[Callable[[int, str], None]] = None,
+        on_log: Optional[Callable[[str], None]] = None,
+    ):
+        self.ssh = ssh_client
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.key_path = key_path
+        self.sudo_password = sudo_password
+        self.email = email
+        self.repo_root = Path(repo_root)
+        self._on_step = on_step or (lambda i, name: None)
+        self._on_log = on_log or (lambda line: None)
+
+    def _step(self, idx: int) -> None:
+        self._on_step(idx, STEPS[idx])
+
+    def _run_checked(
+        self,
+        cmd: str,
+        timeout: float = 1800.0,
+        what: str = "",
+        *,
+        privileged: bool = True,
+    ) -> list[str]:
+        lines: list[str] = []
+
+        def collect(line: str) -> None:
+            lines.append(line)
+            self._on_log(line)
+
+        rc = self.ssh.run_streaming(
+            cmd,
+            on_line=collect,
+            timeout=timeout,
+            privileged=privileged,
+        )
+        if rc != 0:
+            raise DeployError(
+                f"Команда завершилась с кодом {rc}: {what or cmd}\n"
+                f"Последние строки вывода:\n" + "\n".join(lines[-5:])
+            )
+        return lines
+
+    def run(self) -> dict:
+        """Выполнить все шаги. Возвращает dict результата quickstart.
+
+        {"ok": True, "subscription_url": ..., "base_url": ..., "profile": ...}
+        """
+        install_sh = self.repo_root / "install.sh"
+        xrayebator_bin = self.repo_root / "xrayebator"
+        if not install_sh.is_file() or not xrayebator_bin.is_file():
+            raise DeployError(
+                f"Не найдены install.sh/xrayebator в корне репозитория: {self.repo_root}"
+            )
+
+        remote_dir: Optional[str] = None
+        try:
+            # 1. Подключение
+            self._step(0)
+            self.ssh.connect(
+                self.host,
+                self.port,
+                self.user,
+                password=self.password,
+                key_path=self.key_path,
+                sudo_password=self.sudo_password,
+            )
+
+            # 2. Проверка ОС
+            self._step(1)
+            os_lines: list[str] = []
+            rc = self.ssh.run_streaming(
+                "cat /etc/os-release",
+                on_line=os_lines.append,
+                timeout=30,
+                privileged=False,
+            )
+            if rc != 0:
+                raise DeployError("Не удалось прочитать /etc/os-release на сервере")
+            os_id, version = check_os_supported("\n".join(os_lines))
+            self._on_log(f"ОС сервера: {os_id} {version} — поддерживается")
+
+            # 3. Загрузка файлов
+            self._step(2)
+            staging_lines = self._run_checked(
+                "mktemp -d /tmp/xrayebator-deploy.XXXXXXXXXX",
+                timeout=30,
+                what="mktemp",
+                privileged=False,
+            )
+            staging_dir = staging_lines[-1].strip() if staging_lines else ""
+            if not re.fullmatch(
+                r"/tmp/xrayebator-deploy\.[A-Za-z0-9]{6,32}",
+                staging_dir,
+            ):
+                raise DeployError(
+                    f"Сервер вернул небезопасный временный путь: {staging_dir!r}"
+                )
+            remote_dir = staging_dir
+            self.ssh.upload(install_sh, f"{remote_dir}/install.sh")
+            self.ssh.upload(xrayebator_bin, f"{remote_dir}/xrayebator")
+            self._on_log("Файлы загружены в " + remote_dir)
+
+            # 4. install.sh (долго)
+            self._step(3)
+            self._run_checked(
+                f"bash {remote_dir}/install.sh",
+                timeout=3600,
+                what="bash install.sh",
+            )
+
+            # 5. Локальный xrayebator поверх релизного (в нём есть quickstart)
+            self._step(4)
+            self._run_checked(
+                f"install -m 0755 -o root -g root {remote_dir}/xrayebator "
+                "/usr/local/bin/xrayebator",
+                timeout=60,
+                what="install xrayebator",
+            )
+
+            # 6. quickstart
+            self._step(5)
+            lines = self._run_checked(
+                f"xrayebator quickstart --email {shlex.quote(self.email)}",
+                timeout=3600,
+                what="xrayebator quickstart",
+            )
+            result = self._parse_result(lines)
+            if not result.get("ok"):
+                raise DeployError(
+                    "quickstart завершился с ошибкой: "
+                    + result.get("error", "неизвестная ошибка")
+                    + "\nПроверьте, что порты 80/443 открыты у провайдера "
+                    "(нужны для Let's Encrypt)."
+                )
+
+            # 7. Готово (сохранение выполняет вызывающий код через servers.py)
+            self._step(6)
+            return result
+        finally:
+            if remote_dir:
+                try:
+                    self.ssh.run_streaming(
+                        f"rm -rf -- {shlex.quote(remote_dir)}",
+                        timeout=30,
+                        privileged=False,
+                    )
+                except Exception:
+                    pass
+            self.ssh.close()
+
+    @staticmethod
+    def _parse_result(lines: list[str]) -> dict:
+        """Распарсить ПОСЛЕДНЮЮ JSON-строку stdout quickstart."""
+        for line in reversed(lines):
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and "ok" in data:
+                return data
+        raise DeployError(
+            "quickstart не вернул JSON-результат. "
+            "Возможно, на сервере старая версия xrayebator."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Qt-обёртка (импорт Qt ленивый, чтобы core оставался тестируемым без Qt)
+# ---------------------------------------------------------------------------
+
+def make_deploy_thread(**kwargs):  # pragma: no cover - тонкая обёртка
+    """Создать QThread-обёртку над Deployer. Qt импортируется здесь."""
+    from PySide6.QtCore import QThread, Signal
+
+    class DeployThread(QThread):
+        step_changed = Signal(int, str)
+        log_line = Signal(str)
+        finished_ok = Signal(dict)
+        failed = Signal(str)
+
+        def __init__(self, **kw):
+            super().__init__()
+            self._kw = kw
+
+        def run(self):
+            try:
+                deployer = Deployer(
+                    on_step=lambda i, s: self.step_changed.emit(i, s),
+                    on_log=lambda line: self.log_line.emit(line),
+                    **self._kw,
+                )
+                result = deployer.run()
+            except Exception as e:  # noqa: BLE001 - любая ошибка -> сигнал
+                self.failed.emit(str(e))
+                return
+            self.finished_ok.emit(result)
+
+    return DeployThread(**kwargs)

--- a/gui/xrayebator_gui/core/deploy.py
+++ b/gui/xrayebator_gui/core/deploy.py
@@ -287,6 +287,7 @@ class Deployer:
 # Qt-обёртка (импорт Qt ленивый, чтобы core оставался тестируемым без Qt)
 # ---------------------------------------------------------------------------
 
+
 def make_deploy_thread(**kwargs):  # pragma: no cover - тонкая обёртка
     """Создать QThread-обёртку над Deployer. Qt импортируется здесь."""
     from PySide6.QtCore import QThread, Signal

--- a/gui/xrayebator_gui/core/deploy.py
+++ b/gui/xrayebator_gui/core/deploy.py
@@ -141,7 +141,7 @@ class Deployer:
 
         def collect(line: str) -> None:
             lines.append(line)
-            self._on_log(line)
+            self._on_log(redact_log_line(line))
 
         rc = self.ssh.run_streaming(
             cmd,
@@ -152,7 +152,8 @@ class Deployer:
         if rc != 0:
             raise DeployError(
                 f"Команда завершилась с кодом {rc}: {what or cmd}\n"
-                f"Последние строки вывода:\n" + "\n".join(lines[-5:])
+                f"Последние строки вывода:\n"
+                + "\n".join(redact_log_line(line) for line in lines[-5:])
             )
         return lines
 
@@ -281,6 +282,26 @@ class Deployer:
             "quickstart не вернул JSON-результат. "
             "Возможно, на сервере старая версия xrayebator."
         )
+
+
+def redact_log_line(line: str) -> str:
+    """Remove subscription/VLESS bearer secrets before a line reaches the UI."""
+    if '"subscription_url"' in line:
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(payload, dict) and "subscription_url" in payload:
+                payload["subscription_url"] = "<redacted>"
+                return json.dumps(payload, ensure_ascii=False)
+    line = re.sub(r"vless://[^\s\"']+", "vless://<redacted>", line)
+    return re.sub(
+        r"(https?://[^\s\"']+/(?:sub|subscription)/)[^\s\"']+",
+        r"\1<redacted>",
+        line,
+        flags=re.IGNORECASE,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/gui/xrayebator_gui/core/desktop_backend.py
+++ b/gui/xrayebator_gui/core/desktop_backend.py
@@ -7,6 +7,7 @@ from typing import Optional
 from .connection import ConnectionMode, TunnelBackend
 from .helper_client import HelperClient, HelperTunBackend
 from .local_proxy import LocalProxyBackend
+from .routing import RoutingProfile
 from .subscription import VlessLink
 
 
@@ -31,26 +32,41 @@ class DesktopBackend:
     def _backend(self, mode: ConnectionMode) -> TunnelBackend:
         return self._tun if mode == ConnectionMode.TUN else self._local
 
-    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def prepare(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         selected = self._backend(mode)
         self._selected = selected
         self._mode = mode
-        selected.prepare(route, mode)
+        selected.prepare(route, mode, routing_profile)
 
-    def start(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def start(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         if self._selected is None or mode != self._mode:
             raise RuntimeError("Backend не подготовлен")
-        self._selected.start(route, mode)
+        self._selected.start(route, mode, routing_profile)
 
     def verify(self) -> Optional[str]:
         if self._selected is None:
             return None
         return self._selected.verify()
 
-    def replace(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def replace(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         if self._selected is None or mode != self._mode:
             raise RuntimeError("Активный backend не найден")
-        self._selected.replace(route, mode)
+        self._selected.replace(route, mode, routing_profile)
 
     def stop(self) -> None:
         if self._selected is None:

--- a/gui/xrayebator_gui/core/desktop_backend.py
+++ b/gui/xrayebator_gui/core/desktop_backend.py
@@ -1,0 +1,62 @@
+"""Select the concrete backend for system-proxy or privileged TUN mode."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .connection import ConnectionMode, TunnelBackend
+from .helper_client import HelperClient, HelperTunBackend
+from .local_proxy import LocalProxyBackend
+from .subscription import VlessLink
+
+
+class DesktopBackend:
+    def __init__(
+        self,
+        *,
+        local: Optional[TunnelBackend] = None,
+        tun: Optional[TunnelBackend] = None,
+        helper_client: Optional[HelperClient] = None,
+    ):
+        self._local = local or LocalProxyBackend()
+        self._helper_client = helper_client or HelperClient()
+        self._tun = tun or HelperTunBackend(self._helper_client)
+        self._selected: Optional[TunnelBackend] = None
+        self._mode: Optional[ConnectionMode] = None
+
+    @property
+    def tun_available(self) -> bool:
+        return self._helper_client.available()
+
+    def _backend(self, mode: ConnectionMode) -> TunnelBackend:
+        return self._tun if mode == ConnectionMode.TUN else self._local
+
+    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None:
+        selected = self._backend(mode)
+        self._selected = selected
+        self._mode = mode
+        selected.prepare(route, mode)
+
+    def start(self, route: VlessLink, mode: ConnectionMode) -> None:
+        if self._selected is None or mode != self._mode:
+            raise RuntimeError("Backend не подготовлен")
+        self._selected.start(route, mode)
+
+    def verify(self) -> Optional[str]:
+        if self._selected is None:
+            return None
+        return self._selected.verify()
+
+    def replace(self, route: VlessLink, mode: ConnectionMode) -> None:
+        if self._selected is None or mode != self._mode:
+            raise RuntimeError("Активный backend не найден")
+        self._selected.replace(route, mode)
+
+    def stop(self) -> None:
+        if self._selected is None:
+            return
+        try:
+            self._selected.stop()
+        finally:
+            self._selected = None
+            self._mode = None

--- a/gui/xrayebator_gui/core/helper_client.py
+++ b/gui/xrayebator_gui/core/helper_client.py
@@ -15,6 +15,7 @@ from .helper_protocol import (
     decode_response,
     encode_request,
 )
+from .routing import RoutingProfile
 from .subscription import VlessLink
 
 DEFAULT_SOCKET = Path("/run/xrayebator-gui/helper.sock")
@@ -45,10 +46,11 @@ class HelperClient:
         self,
         action: str,
         route: Optional[VlessLink] = None,
+        routing_profile: Optional[RoutingProfile] = None,
     ) -> dict:
         if platform.system() != "Linux":
             raise HelperError("Privileged TUN helper пока реализован только для Linux")
-        wire = encode_request(action, route)
+        wire = encode_request(action, route, routing_profile)
         request_id = json.loads(wire)["id"]
         try:
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
@@ -91,23 +93,38 @@ class HelperTunBackend:
     def __init__(self, client: Optional[HelperClient] = None):
         self.client = client or HelperClient()
 
-    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def prepare(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         if mode != ConnectionMode.TUN:
             raise HelperError("HelperTunBackend поддерживает только TUN")
         self.client.request("status")
 
-    def start(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def start(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         if mode != ConnectionMode.TUN:
             raise HelperError("HelperTunBackend поддерживает только TUN")
-        self.client.request("connect", route)
+        self.client.request("connect", route, routing_profile)
 
     def verify(self) -> Optional[str]:
         return self.client.request("verify").get("external_ip")
 
-    def replace(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def replace(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         if mode != ConnectionMode.TUN:
             raise HelperError("HelperTunBackend поддерживает только TUN")
-        self.client.request("switch", route)
+        self.client.request("switch", route, routing_profile)
 
     def stop(self) -> None:
         self.client.request("disconnect")

--- a/gui/xrayebator_gui/core/helper_client.py
+++ b/gui/xrayebator_gui/core/helper_client.py
@@ -1,0 +1,113 @@
+"""Desktop-side client for the local privileged TUN helper."""
+
+from __future__ import annotations
+
+import json
+import platform
+import socket
+from pathlib import Path
+from typing import Optional
+
+from .connection import ConnectionMode
+from .helper_protocol import (
+    MAX_MESSAGE_BYTES,
+    ProtocolError,
+    decode_response,
+    encode_request,
+)
+from .subscription import VlessLink
+
+DEFAULT_SOCKET = Path("/run/xrayebator-gui/helper.sock")
+
+
+class HelperError(RuntimeError):
+    """Privileged helper is unavailable or rejected an operation."""
+
+
+class HelperClient:
+    def __init__(
+        self,
+        socket_path: Path = DEFAULT_SOCKET,
+        *,
+        timeout: float = 15.0,
+    ):
+        self.socket_path = Path(socket_path)
+        self.timeout = timeout
+
+    def available(self) -> bool:
+        try:
+            self.request("status")
+        except HelperError:
+            return False
+        return True
+
+    def request(
+        self,
+        action: str,
+        route: Optional[VlessLink] = None,
+    ) -> dict:
+        if platform.system() != "Linux":
+            raise HelperError("Privileged TUN helper пока реализован только для Linux")
+        wire = encode_request(action, route)
+        request_id = json.loads(wire)["id"]
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(self.timeout)
+                client.connect(str(self.socket_path))
+                client.sendall(wire)
+                response = _read_line(client)
+        except (OSError, TimeoutError) as exc:
+            raise HelperError(
+                f"Privileged helper недоступен ({self.socket_path}): {exc}"
+            ) from exc
+        try:
+            payload = decode_response(response, request_id)
+        except ProtocolError as exc:
+            raise HelperError(str(exc)) from exc
+        if not payload["ok"]:
+            raise HelperError(payload["error"] or "Операция helper не выполнена")
+        return payload
+
+
+def _read_line(sock: socket.socket) -> bytes:
+    chunks = bytearray()
+    while True:
+        chunk = sock.recv(min(65536, MAX_MESSAGE_BYTES + 1 - len(chunks)))
+        if not chunk:
+            raise HelperError("Privileged helper закрыл соединение без ответа")
+        chunks.extend(chunk)
+        if len(chunks) > MAX_MESSAGE_BYTES:
+            raise HelperError("Ответ privileged helper слишком велик")
+        newline = chunks.find(b"\n")
+        if newline >= 0:
+            if chunks[newline + 1 :]:
+                raise HelperError("Privileged helper вернул несколько сообщений")
+            return bytes(chunks[:newline])
+
+
+class HelperTunBackend:
+    """Connection backend that delegates all privileged state to the helper."""
+
+    def __init__(self, client: Optional[HelperClient] = None):
+        self.client = client or HelperClient()
+
+    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None:
+        if mode != ConnectionMode.TUN:
+            raise HelperError("HelperTunBackend поддерживает только TUN")
+        self.client.request("status")
+
+    def start(self, route: VlessLink, mode: ConnectionMode) -> None:
+        if mode != ConnectionMode.TUN:
+            raise HelperError("HelperTunBackend поддерживает только TUN")
+        self.client.request("connect", route)
+
+    def verify(self) -> Optional[str]:
+        return self.client.request("verify").get("external_ip")
+
+    def replace(self, route: VlessLink, mode: ConnectionMode) -> None:
+        if mode != ConnectionMode.TUN:
+            raise HelperError("HelperTunBackend поддерживает только TUN")
+        self.client.request("switch", route)
+
+    def stop(self) -> None:
+        self.client.request("disconnect")

--- a/gui/xrayebator_gui/core/helper_install.py
+++ b/gui/xrayebator_gui/core/helper_install.py
@@ -1,0 +1,58 @@
+"""User-triggered installation of the root-owned Linux TUN helper."""
+
+from __future__ import annotations
+
+import os
+import platform
+import pwd
+import shutil
+import subprocess
+from pathlib import Path
+
+
+class HelperInstallError(RuntimeError):
+    """The local privileged helper could not be installed."""
+
+
+def linux_installer_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "resources"
+        / "linux"
+        / "install-helper.sh"
+    )
+
+
+def install_linux_helper(timeout: float = 600.0) -> str:
+    if platform.system() != "Linux":
+        raise HelperInstallError(
+            "Автоустановка privileged helper поддержана только в Linux"
+        )
+    pkexec = shutil.which("pkexec")
+    if pkexec is None:
+        raise HelperInstallError(
+            "Не найден pkexec. Установите polkit или запустите "
+            "resources/linux/install-helper.sh через sudo."
+        )
+    script = linux_installer_path()
+    if not script.is_file():
+        raise HelperInstallError(f"Не найден installer helper: {script}")
+    username = pwd.getpwuid(os.getuid()).pw_name
+    try:
+        result = subprocess.run(
+            [pkexec, "bash", str(script), "--user", username],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise HelperInstallError(f"Не удалось запустить installer: {exc}") from exc
+    output = "\n".join(
+        part.strip() for part in (result.stdout, result.stderr) if part.strip()
+    )
+    if result.returncode != 0:
+        raise HelperInstallError(
+            output or f"Installer helper завершился с кодом {result.returncode}"
+        )
+    return output or "Privileged TUN helper установлен"

--- a/gui/xrayebator_gui/core/helper_install.py
+++ b/gui/xrayebator_gui/core/helper_install.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import os
+import getpass
 import platform
-import pwd
 import shutil
 import subprocess
 from pathlib import Path
@@ -37,7 +36,7 @@ def install_linux_helper(timeout: float = 600.0) -> str:
     script = linux_installer_path()
     if not script.is_file():
         raise HelperInstallError(f"Не найден installer helper: {script}")
-    username = pwd.getpwuid(os.getuid()).pw_name
+    username = getpass.getuser()
     try:
         result = subprocess.run(
             [pkexec, "bash", str(script), "--user", username],

--- a/gui/xrayebator_gui/core/helper_protocol.py
+++ b/gui/xrayebator_gui/core/helper_protocol.py
@@ -7,6 +7,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from .routing import RoutingProfile
 from .subscription import VlessLink, parse_link
 
 PROTOCOL_VERSION = 1
@@ -23,13 +24,20 @@ class HelperRequest:
     request_id: str
     action: str
     route: Optional[VlessLink] = None
+    routing_profile: Optional[RoutingProfile] = None
 
 
-def encode_request(action: str, route: Optional[VlessLink] = None) -> bytes:
+def encode_request(
+    action: str,
+    route: Optional[VlessLink] = None,
+    routing_profile: Optional[RoutingProfile] = None,
+) -> bytes:
     if action not in COMMANDS:
         raise ProtocolError(f"Неизвестная команда helper: {action}")
     if action in {"connect", "switch"} and route is None:
         raise ProtocolError(f"Команда {action} требует маршрут")
+    if action in {"connect", "switch"} and routing_profile is None:
+        raise ProtocolError(f"Команда {action} требует routing profile")
     payload: dict[str, Any] = {
         "version": PROTOCOL_VERSION,
         "id": uuid.uuid4().hex,
@@ -37,6 +45,8 @@ def encode_request(action: str, route: Optional[VlessLink] = None) -> bytes:
     }
     if route is not None:
         payload["route"] = route.raw
+    if routing_profile is not None:
+        payload["routing_profile"] = routing_profile.value
     return _encode(payload)
 
 
@@ -45,7 +55,7 @@ def decode_request(data: bytes) -> HelperRequest:
     _require_exact_keys(
         payload,
         required={"version", "id", "action"},
-        optional={"route"},
+        optional={"route", "routing_profile"},
     )
     if payload["version"] != PROTOCOL_VERSION:
         raise ProtocolError(
@@ -58,17 +68,32 @@ def decode_request(data: bytes) -> HelperRequest:
     if not isinstance(action, str) or action not in COMMANDS:
         raise ProtocolError("Некорректная команда helper")
     route = None
+    routing_profile = None
     if "route" in payload:
         if not isinstance(payload["route"], str):
             raise ProtocolError("Маршрут должен быть строкой vless://")
         route = parse_link(payload["route"])
         if route is None:
             raise ProtocolError("Некорректный VLESS-маршрут")
+    if "routing_profile" in payload:
+        try:
+            routing_profile = RoutingProfile(payload["routing_profile"])
+        except (ValueError, TypeError) as exc:
+            raise ProtocolError("Некорректный routing profile") from exc
     if action in {"connect", "switch"} and route is None:
         raise ProtocolError(f"Команда {action} требует маршрут")
-    if action not in {"connect", "switch"} and route is not None:
-        raise ProtocolError(f"Команда {action} не принимает маршрут")
-    return HelperRequest(request_id=request_id, action=action, route=route)
+    if action in {"connect", "switch"} and routing_profile is None:
+        raise ProtocolError(f"Команда {action} требует routing profile")
+    if action not in {"connect", "switch"} and (
+        route is not None or routing_profile is not None
+    ):
+        raise ProtocolError(f"Команда {action} не принимает маршрут/профиль")
+    return HelperRequest(
+        request_id=request_id,
+        action=action,
+        route=route,
+        routing_profile=routing_profile,
+    )
 
 
 def encode_response(

--- a/gui/xrayebator_gui/core/helper_protocol.py
+++ b/gui/xrayebator_gui/core/helper_protocol.py
@@ -12,7 +12,14 @@ from .subscription import VlessLink, parse_link
 
 PROTOCOL_VERSION = 1
 MAX_MESSAGE_BYTES = 256 * 1024
-COMMANDS = {"status", "connect", "switch", "verify", "disconnect"}
+COMMANDS = {
+    "status",
+    "selftest",
+    "connect",
+    "switch",
+    "verify",
+    "disconnect",
+}
 
 
 class ProtocolError(ValueError):

--- a/gui/xrayebator_gui/core/helper_protocol.py
+++ b/gui/xrayebator_gui/core/helper_protocol.py
@@ -1,0 +1,172 @@
+"""Strict JSON protocol shared by the desktop process and privileged helper."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .subscription import VlessLink, parse_link
+
+PROTOCOL_VERSION = 1
+MAX_MESSAGE_BYTES = 256 * 1024
+COMMANDS = {"status", "connect", "switch", "verify", "disconnect"}
+
+
+class ProtocolError(ValueError):
+    """Malformed or unsupported helper message."""
+
+
+@dataclass(frozen=True)
+class HelperRequest:
+    request_id: str
+    action: str
+    route: Optional[VlessLink] = None
+
+
+def encode_request(action: str, route: Optional[VlessLink] = None) -> bytes:
+    if action not in COMMANDS:
+        raise ProtocolError(f"Неизвестная команда helper: {action}")
+    if action in {"connect", "switch"} and route is None:
+        raise ProtocolError(f"Команда {action} требует маршрут")
+    payload: dict[str, Any] = {
+        "version": PROTOCOL_VERSION,
+        "id": uuid.uuid4().hex,
+        "action": action,
+    }
+    if route is not None:
+        payload["route"] = route.raw
+    return _encode(payload)
+
+
+def decode_request(data: bytes) -> HelperRequest:
+    payload = _decode(data)
+    _require_exact_keys(
+        payload,
+        required={"version", "id", "action"},
+        optional={"route"},
+    )
+    if payload["version"] != PROTOCOL_VERSION:
+        raise ProtocolError(
+            f"Версия helper protocol {payload['version']} не поддерживается"
+        )
+    request_id = payload["id"]
+    action = payload["action"]
+    if not isinstance(request_id, str) or not _valid_request_id(request_id):
+        raise ProtocolError("Некорректный request id")
+    if not isinstance(action, str) or action not in COMMANDS:
+        raise ProtocolError("Некорректная команда helper")
+    route = None
+    if "route" in payload:
+        if not isinstance(payload["route"], str):
+            raise ProtocolError("Маршрут должен быть строкой vless://")
+        route = parse_link(payload["route"])
+        if route is None:
+            raise ProtocolError("Некорректный VLESS-маршрут")
+    if action in {"connect", "switch"} and route is None:
+        raise ProtocolError(f"Команда {action} требует маршрут")
+    if action not in {"connect", "switch"} and route is not None:
+        raise ProtocolError(f"Команда {action} не принимает маршрут")
+    return HelperRequest(request_id=request_id, action=action, route=route)
+
+
+def encode_response(
+    request_id: str,
+    *,
+    ok: bool,
+    state: str,
+    external_ip: Optional[str] = None,
+    error: Optional[str] = None,
+) -> bytes:
+    payload = {
+        "version": PROTOCOL_VERSION,
+        "id": request_id,
+        "ok": ok,
+        "state": state,
+        "external_ip": external_ip,
+        "error": error,
+    }
+    return _encode(payload)
+
+
+def decode_response(data: bytes, expected_id: str) -> dict[str, Any]:
+    payload = _decode(data)
+    _require_exact_keys(
+        payload,
+        required={
+            "version",
+            "id",
+            "ok",
+            "state",
+            "external_ip",
+            "error",
+        },
+    )
+    if payload["version"] != PROTOCOL_VERSION:
+        raise ProtocolError("Несовместимая версия privileged helper")
+    if payload["id"] != expected_id:
+        raise ProtocolError("Ответ privileged helper имеет другой request id")
+    if not isinstance(payload["ok"], bool):
+        raise ProtocolError("Поле ok в ответе helper должно быть bool")
+    if not isinstance(payload["state"], str):
+        raise ProtocolError("Поле state в ответе helper должно быть строкой")
+    for key in ("external_ip", "error"):
+        if payload[key] is not None and not isinstance(payload[key], str):
+            raise ProtocolError(f"Поле {key} в ответе helper некорректно")
+    return payload
+
+
+def request_id_from_wire(data: bytes) -> str:
+    """Best-effort id extraction for an error response."""
+    try:
+        value = json.loads(data.decode("utf-8")).get("id", "")
+    except (UnicodeDecodeError, json.JSONDecodeError, AttributeError):
+        return ""
+    return value if isinstance(value, str) and _valid_request_id(value) else ""
+
+
+def _encode(payload: dict[str, Any]) -> bytes:
+    data = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(data) > MAX_MESSAGE_BYTES:
+        raise ProtocolError("Сообщение helper слишком велико")
+    return data + b"\n"
+
+
+def _decode(data: bytes) -> dict[str, Any]:
+    if len(data) > MAX_MESSAGE_BYTES:
+        raise ProtocolError("Сообщение helper слишком велико")
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtocolError("Некорректный JSON helper protocol") from exc
+    if not isinstance(payload, dict):
+        raise ProtocolError("Сообщение helper должно быть JSON-объектом")
+    return payload
+
+
+def _require_exact_keys(
+    payload: dict[str, Any],
+    *,
+    required: set[str],
+    optional: Optional[set[str]] = None,
+) -> None:
+    optional = optional or set()
+    missing = required - payload.keys()
+    unknown = payload.keys() - required - optional
+    if missing:
+        raise ProtocolError(
+            "В сообщении helper отсутствуют поля: " + ", ".join(sorted(missing))
+        )
+    if unknown:
+        raise ProtocolError(
+            "Неизвестные поля helper protocol: " + ", ".join(sorted(unknown))
+        )
+
+
+def _valid_request_id(value: str) -> bool:
+    return bool(value) and len(value) <= 64 and value.isalnum()

--- a/gui/xrayebator_gui/core/latency.py
+++ b/gui/xrayebator_gui/core/latency.py
@@ -1,0 +1,53 @@
+"""Bounded parallel TCP latency probes for subscription routes."""
+
+from __future__ import annotations
+
+import socket
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Iterable, Optional
+
+from .subscription import VlessLink
+
+
+def probe_endpoint(
+    host: str,
+    port: int,
+    *,
+    timeout: float = 2.0,
+) -> Optional[int]:
+    started = time.perf_counter()
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            elapsed = time.perf_counter() - started
+    except OSError:
+        return None
+    return max(1, round(elapsed * 1000))
+
+
+def probe_routes(
+    routes: Iterable[VlessLink],
+    *,
+    timeout: float = 2.0,
+    max_workers: int = 8,
+) -> dict[str, Optional[int]]:
+    route_list = list(routes)
+    endpoints = {(route.address, route.port) for route in route_list}
+    endpoint_latency: dict[tuple[str, int], Optional[int]] = {}
+    with ThreadPoolExecutor(
+        max_workers=min(max_workers, max(1, len(endpoints)))
+    ) as executor:
+        futures = {
+            executor.submit(
+                probe_endpoint,
+                host,
+                port,
+                timeout=timeout,
+            ): (host, port)
+            for host, port in endpoints
+        }
+        for future in as_completed(futures):
+            endpoint_latency[futures[future]] = future.result()
+    return {
+        route.raw: endpoint_latency[(route.address, route.port)] for route in route_list
+    }

--- a/gui/xrayebator_gui/core/local_proxy.py
+++ b/gui/xrayebator_gui/core/local_proxy.py
@@ -1,0 +1,99 @@
+"""Concrete local Xray backend for the current system-proxy connection mode."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+from . import proxy
+from .connection import ConnectionMode
+from .subscription import VlessLink
+from .xray import HTTP_PORT, XrayError, XrayProcess, build_client_config, ensure_binary
+
+
+class LocalProxyBackend:
+    """Run Xray locally and expose it through the operating-system proxy.
+
+    This backend intentionally rejects TUN. TUN needs a privileged service,
+    route/DNS guards, and separate verification before it can share this
+    lifecycle contract.
+    """
+
+    def __init__(
+        self,
+        *,
+        ensure_binary_fn: Callable[[], Path] = ensure_binary,
+        process_factory: Callable[[Path], XrayProcess] = XrayProcess,
+    ):
+        self._ensure_binary = ensure_binary_fn
+        self._process_factory = process_factory
+        self._process: Optional[XrayProcess] = None
+        self._pending_config: Optional[dict] = None
+        self._proxy_snapshot: Optional[proxy.ProxySnapshot] = None
+
+    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None:
+        if mode != ConnectionMode.SYSTEM_PROXY:
+            raise XrayError(
+                "TUN ещё не активирован: требуется privileged network service"
+            )
+        binary = self._ensure_binary()
+        if self._process is None:
+            self._process = self._process_factory(binary)
+        self._pending_config = build_client_config(route)
+
+    def start(self, route: VlessLink, mode: ConnectionMode) -> None:
+        if mode != ConnectionMode.SYSTEM_PROXY:
+            raise XrayError("LocalProxyBackend поддерживает только system proxy")
+        if self._process is None or self._pending_config is None:
+            raise XrayError("Backend не подготовлен к запуску")
+
+        snapshot = proxy.capture()
+        self._process.start(self._pending_config)
+        try:
+            enabled = proxy.enable(port=HTTP_PORT)
+        except Exception:
+            proxy.restore(snapshot)
+            self._process.stop()
+            raise
+        if not enabled:
+            proxy.restore(snapshot)
+            self._process.stop()
+            raise XrayError(
+                "Не удалось включить системный proxy автоматически. "
+                f"Настройте HTTP proxy 127.0.0.1:{HTTP_PORT} вручную."
+            )
+        self._proxy_snapshot = snapshot
+
+    def verify(self) -> Optional[str]:
+        if self._process is None:
+            return None
+        return self._process.health_check()
+
+    def replace(self, route: VlessLink, mode: ConnectionMode) -> None:
+        """Replace Xray config while keeping the system proxy guard enabled."""
+        if mode != ConnectionMode.SYSTEM_PROXY:
+            raise XrayError("LocalProxyBackend поддерживает только system proxy")
+        binary = self._ensure_binary()
+        if self._process is None:
+            self._process = self._process_factory(binary)
+        self._pending_config = build_client_config(route)
+        self._process.start(self._pending_config)
+
+    def stop(self) -> None:
+        errors: list[str] = []
+        if self._proxy_snapshot is not None:
+            try:
+                restored = proxy.restore(self._proxy_snapshot)
+                if not restored:
+                    errors.append("system proxy: прежние настройки не восстановлены")
+            except Exception as exc:  # cleanup must still stop Xray
+                errors.append(f"system proxy: {exc}")
+            self._proxy_snapshot = None
+        if self._process is not None:
+            try:
+                self._process.stop()
+            except Exception as exc:
+                errors.append(f"xray: {exc}")
+        self._pending_config = None
+        if errors:
+            raise XrayError("; ".join(errors))

--- a/gui/xrayebator_gui/core/local_proxy.py
+++ b/gui/xrayebator_gui/core/local_proxy.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 
 from . import proxy
 from .connection import ConnectionMode
+from .routing import RoutingProfile
 from .subscription import VlessLink
 from .xray import HTTP_PORT, XrayError, XrayProcess, build_client_config, ensure_binary
 
@@ -31,7 +32,12 @@ class LocalProxyBackend:
         self._pending_config: Optional[dict] = None
         self._proxy_snapshot: Optional[proxy.ProxySnapshot] = None
 
-    def prepare(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def prepare(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         if mode != ConnectionMode.SYSTEM_PROXY:
             raise XrayError(
                 "TUN ещё не активирован: требуется privileged network service"
@@ -39,9 +45,17 @@ class LocalProxyBackend:
         binary = self._ensure_binary()
         if self._process is None:
             self._process = self._process_factory(binary)
-        self._pending_config = build_client_config(route)
+        self._pending_config = build_client_config(
+            route,
+            routing_profile=routing_profile,
+        )
 
-    def start(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def start(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         if mode != ConnectionMode.SYSTEM_PROXY:
             raise XrayError("LocalProxyBackend поддерживает только system proxy")
         if self._process is None or self._pending_config is None:
@@ -69,14 +83,22 @@ class LocalProxyBackend:
             return None
         return self._process.health_check()
 
-    def replace(self, route: VlessLink, mode: ConnectionMode) -> None:
+    def replace(
+        self,
+        route: VlessLink,
+        mode: ConnectionMode,
+        routing_profile: RoutingProfile,
+    ) -> None:
         """Replace Xray config while keeping the system proxy guard enabled."""
         if mode != ConnectionMode.SYSTEM_PROXY:
             raise XrayError("LocalProxyBackend поддерживает только system proxy")
         binary = self._ensure_binary()
         if self._process is None:
             self._process = self._process_factory(binary)
-        self._pending_config = build_client_config(route)
+        self._pending_config = build_client_config(
+            route,
+            routing_profile=routing_profile,
+        )
         self._process.start(self._pending_config)
 
     def stop(self) -> None:

--- a/gui/xrayebator_gui/core/proxy.py
+++ b/gui/xrayebator_gui/core/proxy.py
@@ -1,0 +1,357 @@
+"""Системный прокси per-OS: Windows (winreg), macOS (networksetup), Linux (gsettings)."""
+
+from __future__ import annotations
+
+import ctypes
+import platform
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+
+class UnsupportedPlatform(Exception):
+    """ОС/DE не поддерживается для автонастройки прокси."""
+
+
+@dataclass(frozen=True)
+class ProxySnapshot:
+    """Настройки, которые приложение обязано вернуть при отключении."""
+
+    system: str
+    values: Any
+
+
+def capture() -> ProxySnapshot:
+    """Снять только те системные настройки, которые меняет этот модуль."""
+    system = platform.system()
+    if system == "Windows":
+        return ProxySnapshot(system, _win_capture())
+    if system == "Darwin":
+        return ProxySnapshot(system, _mac_capture())
+    if system == "Linux":
+        return ProxySnapshot(system, _linux_capture())
+    raise UnsupportedPlatform(f"Неподдерживаемая ОС: {system}")
+
+
+def restore(snapshot: ProxySnapshot) -> bool:
+    """Восстановить ранее снятые настройки без подмены текущей ОС."""
+    system = platform.system()
+    if snapshot.system != system:
+        raise UnsupportedPlatform(
+            f"Снимок proxy создан для {snapshot.system}, текущая ОС — {system}"
+        )
+    if system == "Windows":
+        return _win_restore(snapshot.values)
+    if system == "Darwin":
+        return _mac_restore(snapshot.values)
+    if system == "Linux":
+        return _linux_restore(snapshot.values)
+    raise UnsupportedPlatform(f"Неподдерживаемая ОС: {system}")
+
+
+def enable(host: str = "127.0.0.1", port: int = 10809) -> bool:
+    """Включить системный HTTP/HTTPS proxy. False — сделайте вручную."""
+    system = platform.system()
+    if system == "Windows":
+        return _win_enable(host, port)
+    if system == "Darwin":
+        return _mac_enable(host, port)
+    if system == "Linux":
+        return _linux_enable(host, port)
+    raise UnsupportedPlatform(f"Неподдерживаемая ОС: {system}")
+
+
+def disable() -> bool:
+    """Выключить системный прокси."""
+    system = platform.system()
+    if system == "Windows":
+        return _win_disable()
+    if system == "Darwin":
+        return _mac_disable()
+    if system == "Linux":
+        return _linux_disable()
+    raise UnsupportedPlatform(f"Неподдерживаемая ОС: {system}")
+
+
+def is_enabled() -> bool:
+    system = platform.system()
+    try:
+        if system == "Windows":
+            import winreg
+
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Internet Settings",
+            ) as k:
+                return bool(winreg.QueryValueEx(k, "ProxyEnable")[0])
+        if system == "Darwin":
+            services = _mac_services()
+            if not services:
+                return False
+            out = subprocess.run(
+                ["networksetup", "-getwebproxy", services[0]],
+                capture_output=True, text=True, timeout=10,
+            ).stdout
+            return "Enabled: Yes" in out
+        if system == "Linux":
+            if not shutil.which("gsettings"):
+                return False
+            out = subprocess.run(
+                ["gsettings", "get", "org.gnome.system.proxy", "mode"],
+                capture_output=True, text=True, timeout=10,
+            ).stdout.strip()
+            return out == "'manual'"
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return False
+
+
+# --- Windows ---------------------------------------------------------------
+
+_WIN_PROXY_KEY = (
+    r"Software\Microsoft\Windows\CurrentVersion\Internet Settings"
+)
+_WIN_PROXY_VALUES = ("ProxyEnable", "ProxyServer", "ProxyOverride")
+
+
+def _win_capture() -> dict[str, tuple[bool, Any, int | None]]:
+    import winreg
+
+    values: dict[str, tuple[bool, Any, int | None]] = {}
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _WIN_PROXY_KEY) as key:
+        for name in _WIN_PROXY_VALUES:
+            try:
+                value, value_type = winreg.QueryValueEx(key, name)
+                values[name] = (True, value, value_type)
+            except FileNotFoundError:
+                values[name] = (False, None, None)
+    return values
+
+
+def _win_restore(values: dict[str, tuple[bool, Any, int | None]]) -> bool:
+    import winreg
+
+    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _WIN_PROXY_KEY) as key:
+        for name in _WIN_PROXY_VALUES:
+            existed, value, value_type = values[name]
+            if existed:
+                winreg.SetValueEx(key, name, 0, value_type, value)
+            else:
+                try:
+                    winreg.DeleteValue(key, name)
+                except FileNotFoundError:
+                    pass
+    _win_apply_settings()
+    return True
+
+
+def _win_apply_settings() -> None:
+    """Уведомить систему об изменении настроек прокси без перелогина."""
+    wininet = ctypes.windll.wininet  # type: ignore[attr-defined]
+    INTERNET_OPTION_SETTINGS_CHANGED = 39
+    INTERNET_OPTION_REFRESH = 41
+    wininet.InternetSetOptionW(0, INTERNET_OPTION_SETTINGS_CHANGED, 0, 0)
+    wininet.InternetSetOptionW(0, INTERNET_OPTION_REFRESH, 0, 0)
+
+
+def _win_enable(host: str, port: int) -> bool:
+    import winreg
+
+    with winreg.CreateKey(
+        winreg.HKEY_CURRENT_USER,
+        _WIN_PROXY_KEY,
+    ) as k:
+        winreg.SetValueEx(k, "ProxyEnable", 0, winreg.REG_DWORD, 1)
+        winreg.SetValueEx(k, "ProxyServer", 0, winreg.REG_SZ, f"{host}:{port}")
+        winreg.SetValueEx(k, "ProxyOverride", 0, winreg.REG_SZ, "<local>")
+    _win_apply_settings()
+    return True
+
+
+def _win_disable() -> bool:
+    import winreg
+
+    with winreg.CreateKey(
+        winreg.HKEY_CURRENT_USER,
+        _WIN_PROXY_KEY,
+    ) as k:
+        winreg.SetValueEx(k, "ProxyEnable", 0, winreg.REG_DWORD, 0)
+    _win_apply_settings()
+    return True
+
+
+# --- macOS -----------------------------------------------------------------
+
+def _mac_services() -> list[str]:
+    """Активные network services (строки со '*' — отключённые, пропускаем)."""
+    out = subprocess.run(
+        ["networksetup", "-listallnetworkservices"],
+        capture_output=True, text=True, timeout=15,
+    ).stdout
+    services = []
+    for line in out.splitlines()[1:]:  # первая строка — заголовок
+        line = line.strip()
+        if line and not line.startswith("*"):
+            services.append(line)
+    return services
+
+
+def _mac_run(args: list[str]) -> None:
+    result = subprocess.run(
+        ["networksetup", *args],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise UnsupportedPlatform(
+            result.stderr.strip() or f"networksetup завершился с {result.returncode}"
+        )
+
+
+def _mac_proxy(service: str, secure: bool) -> dict[str, Any]:
+    command = "-getsecurewebproxy" if secure else "-getwebproxy"
+    result = subprocess.run(
+        ["networksetup", command, service],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        raise UnsupportedPlatform(
+            result.stderr.strip() or f"Не удалось прочитать proxy для {service}"
+        )
+    fields = {}
+    for line in result.stdout.splitlines():
+        match = re.match(r"^([^:]+):\s*(.*)$", line)
+        if match:
+            fields[match.group(1).strip()] = match.group(2).strip()
+    try:
+        return {
+            "enabled": fields.get("Enabled") == "Yes",
+            "server": fields.get("Server", ""),
+            "port": int(fields.get("Port", "0")),
+        }
+    except ValueError as exc:
+        raise UnsupportedPlatform(
+            f"Некорректный ответ networksetup для {service}"
+        ) from exc
+
+
+def _mac_capture() -> dict[str, dict[str, dict[str, Any]]]:
+    return {
+        service: {
+            "web": _mac_proxy(service, secure=False),
+            "secure": _mac_proxy(service, secure=True),
+        }
+        for service in _mac_services()
+    }
+
+
+def _mac_restore(values: dict[str, dict[str, dict[str, Any]]]) -> bool:
+    for service, proxies in values.items():
+        for kind, command in (
+            ("web", "-setwebproxy"),
+            ("secure", "-setsecurewebproxy"),
+        ):
+            saved = proxies[kind]
+            if saved["server"] and saved["port"]:
+                _mac_run(
+                    [command, service, saved["server"], str(saved["port"])]
+                )
+            state_command = (
+                "-setwebproxystate"
+                if kind == "web"
+                else "-setsecurewebproxystate"
+            )
+            _mac_run(
+                [state_command, service, "on" if saved["enabled"] else "off"]
+            )
+    return True
+
+
+def _mac_enable(host: str, port: int) -> bool:
+    services = _mac_services()
+    if not services:
+        return False
+    for svc in services:
+        _mac_run(["-setwebproxy", svc, host, str(port)])
+        _mac_run(["-setsecurewebproxy", svc, host, str(port)])
+    return True
+
+
+def _mac_disable() -> bool:
+    services = _mac_services()
+    for svc in services:
+        _mac_run(["-setwebproxystate", svc, "off"])
+        _mac_run(["-setsecurewebproxystate", svc, "off"])
+    return True
+
+
+# --- Linux (GNOME) ----------------------------------------------------------
+
+def _gsettings(*args: str) -> bool:
+    if not shutil.which("gsettings"):
+        return False
+    rc = subprocess.run(
+        ["gsettings", *args], capture_output=True, timeout=10
+    ).returncode
+    return rc == 0
+
+
+def _gsettings_get(schema: str, key: str) -> str:
+    if not shutil.which("gsettings"):
+        raise UnsupportedPlatform(
+            "gsettings не найден; автоматический proxy поддержан только в GNOME"
+        )
+    result = subprocess.run(
+        ["gsettings", "get", schema, key],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise UnsupportedPlatform(
+            result.stderr.strip() or f"Не удалось прочитать {schema} {key}"
+        )
+    return result.stdout.strip()
+
+
+_LINUX_PROXY_KEYS = (
+    ("org.gnome.system.proxy", "mode"),
+    ("org.gnome.system.proxy.http", "host"),
+    ("org.gnome.system.proxy.http", "port"),
+    ("org.gnome.system.proxy.https", "host"),
+    ("org.gnome.system.proxy.https", "port"),
+)
+
+
+def _linux_capture() -> dict[tuple[str, str], str]:
+    return {
+        (schema, key): _gsettings_get(schema, key)
+        for schema, key in _LINUX_PROXY_KEYS
+    }
+
+
+def _linux_restore(values: dict[tuple[str, str], str]) -> bool:
+    ok = True
+    # Mode is restored last so consumers never see a half-restored manual proxy.
+    for schema, key in (*_LINUX_PROXY_KEYS[1:], _LINUX_PROXY_KEYS[0]):
+        ok = _gsettings("set", schema, key, values[(schema, key)]) and ok
+    return ok
+
+
+def _linux_enable(host: str, port: int) -> bool:
+    """GNOME: manual HTTP/HTTPS proxy. False — настройте вручную."""
+    ok = _gsettings("set", "org.gnome.system.proxy", "mode", "'manual'")
+    ok = _gsettings("set", "org.gnome.system.proxy.http", "host", f"'{host}'") and ok
+    ok = _gsettings("set", "org.gnome.system.proxy.http", "port", str(port)) and ok
+    ok = _gsettings("set", "org.gnome.system.proxy.https", "host", f"'{host}'") and ok
+    ok = _gsettings("set", "org.gnome.system.proxy.https", "port", str(port)) and ok
+    return ok
+
+
+def _linux_disable() -> bool:
+    return _gsettings("set", "org.gnome.system.proxy", "mode", "'none'")

--- a/gui/xrayebator_gui/core/proxy.py
+++ b/gui/xrayebator_gui/core/proxy.py
@@ -92,7 +92,9 @@ def is_enabled() -> bool:
                 return False
             out = subprocess.run(
                 ["networksetup", "-getwebproxy", services[0]],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             ).stdout
             return "Enabled: Yes" in out
         if system == "Linux":
@@ -100,7 +102,9 @@ def is_enabled() -> bool:
                 return False
             out = subprocess.run(
                 ["gsettings", "get", "org.gnome.system.proxy", "mode"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             ).stdout.strip()
             return out == "'manual'"
     except (OSError, subprocess.SubprocessError):
@@ -110,9 +114,7 @@ def is_enabled() -> bool:
 
 # --- Windows ---------------------------------------------------------------
 
-_WIN_PROXY_KEY = (
-    r"Software\Microsoft\Windows\CurrentVersion\Internet Settings"
-)
+_WIN_PROXY_KEY = r"Software\Microsoft\Windows\CurrentVersion\Internet Settings"
 _WIN_PROXY_VALUES = ("ProxyEnable", "ProxyServer", "ProxyOverride")
 
 
@@ -184,11 +186,14 @@ def _win_disable() -> bool:
 
 # --- macOS -----------------------------------------------------------------
 
+
 def _mac_services() -> list[str]:
     """Активные network services (строки со '*' — отключённые, пропускаем)."""
     out = subprocess.run(
         ["networksetup", "-listallnetworkservices"],
-        capture_output=True, text=True, timeout=15,
+        capture_output=True,
+        text=True,
+        timeout=15,
     ).stdout
     services = []
     for line in out.splitlines()[1:]:  # первая строка — заголовок
@@ -258,17 +263,11 @@ def _mac_restore(values: dict[str, dict[str, dict[str, Any]]]) -> bool:
         ):
             saved = proxies[kind]
             if saved["server"] and saved["port"]:
-                _mac_run(
-                    [command, service, saved["server"], str(saved["port"])]
-                )
+                _mac_run([command, service, saved["server"], str(saved["port"])])
             state_command = (
-                "-setwebproxystate"
-                if kind == "web"
-                else "-setsecurewebproxystate"
+                "-setwebproxystate" if kind == "web" else "-setsecurewebproxystate"
             )
-            _mac_run(
-                [state_command, service, "on" if saved["enabled"] else "off"]
-            )
+            _mac_run([state_command, service, "on" if saved["enabled"] else "off"])
     return True
 
 
@@ -291,6 +290,7 @@ def _mac_disable() -> bool:
 
 
 # --- Linux (GNOME) ----------------------------------------------------------
+
 
 def _gsettings(*args: str) -> bool:
     if not shutil.which("gsettings"):
@@ -330,8 +330,7 @@ _LINUX_PROXY_KEYS = (
 
 def _linux_capture() -> dict[tuple[str, str], str]:
     return {
-        (schema, key): _gsettings_get(schema, key)
-        for schema, key in _LINUX_PROXY_KEYS
+        (schema, key): _gsettings_get(schema, key) for schema, key in _LINUX_PROXY_KEYS
     }
 
 

--- a/gui/xrayebator_gui/core/routing.py
+++ b/gui/xrayebator_gui/core/routing.py
@@ -1,0 +1,52 @@
+"""Built-in routing profiles shared by UI, desktop backend and helper."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class RoutingProfile(str, Enum):
+    FULL = "full"
+    SMART_RU = "smart_ru"
+
+    @property
+    def label(self) -> str:
+        if self == RoutingProfile.SMART_RU:
+            return "Smart RU — РФ/локальная сеть напрямую, реклама блокируется"
+        return "Full tunnel — весь трафик через VPN"
+
+
+def build_routing_config(profile: RoutingProfile) -> dict | None:
+    if profile == RoutingProfile.FULL:
+        return None
+    if profile == RoutingProfile.SMART_RU:
+        return {
+            "domainStrategy": "IPIfNonMatch",
+            "domainMatcher": "hybrid",
+            "rules": [
+                {
+                    "type": "field",
+                    "domain": ["geosite:category-ads-all"],
+                    "outboundTag": "block",
+                },
+                {
+                    "type": "field",
+                    "ip": ["geoip:private"],
+                    "outboundTag": "direct",
+                },
+                {
+                    "type": "field",
+                    "domain": [
+                        "geosite:private",
+                        "geosite:category-ru",
+                    ],
+                    "outboundTag": "direct",
+                },
+                {
+                    "type": "field",
+                    "ip": ["geoip:ru"],
+                    "outboundTag": "direct",
+                },
+            ],
+        }
+    raise ValueError(f"Неизвестный routing profile: {profile}")

--- a/gui/xrayebator_gui/core/servers.py
+++ b/gui/xrayebator_gui/core/servers.py
@@ -1,0 +1,107 @@
+"""Хранилище серверов: JSON-файл + пароли в keyring.
+
+Пароль никогда не попадает в JSON — только в системное хранилище ключей
+(service "xrayebator-gui", key = id сервера).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import keyring
+from platformdirs import user_data_dir
+
+APP_NAME = "xrayebator-gui"
+KEYRING_SERVICE = "xrayebator-gui"
+
+
+class ServerStore:
+    """Список серверов в user_data_dir("xrayebator-gui")/servers.json."""
+
+    def __init__(self, data_dir: Optional[Path] = None):
+        self._dir = data_dir or Path(user_data_dir(APP_NAME))
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._path = self._dir / "servers.json"
+
+    def _load(self) -> list[dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return []
+        return data if isinstance(data, list) else []
+
+    def _save(self, servers: list[dict[str, Any]]) -> None:
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(servers, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        tmp.replace(self._path)
+
+    def list(self) -> list[dict[str, Any]]:
+        """Все серверы."""
+        return self._load()
+
+    def get(self, server_id: str) -> Optional[dict[str, Any]]:
+        for s in self._load():
+            if s.get("id") == server_id:
+                return s
+        return None
+
+    def add(
+        self,
+        *,
+        name: str,
+        host: str,
+        port: int,
+        user: str,
+        auth_type: str,
+        subscription_url: str,
+        profile: str = "happ",
+        password: Optional[str] = None,
+        key_path: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Добавить сервер. Пароль уходит в keyring, не в JSON.
+
+        Внимание: subscription_url — фактически секрет (токен подписки),
+        поэтому храним JSON только локально в каталоге данных пользователя.
+        """
+        server = {
+            "id": uuid.uuid4().hex,
+            "name": name,
+            "host": host,
+            "port": port,
+            "user": user,
+            "auth_type": auth_type,  # "password" | "key"
+            "subscription_url": subscription_url,
+            "profile": profile,
+            "key_path": key_path or "",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        servers = self._load()
+        servers.append(server)
+        self._save(servers)
+        if password:
+            keyring.set_password(KEYRING_SERVICE, server["id"], password)
+        return server
+
+    def remove(self, server_id: str) -> None:
+        """Удалить сервер и его пароль из keyring."""
+        servers = [s for s in self._load() if s.get("id") != server_id]
+        self._save(servers)
+        try:
+            keyring.delete_password(KEYRING_SERVICE, server_id)
+        except keyring.errors.PasswordDeleteError:
+            pass
+
+    def get_password(self, server_id: str) -> Optional[str]:
+        """Пароль сервера из keyring (None, если не сохранён)."""
+        try:
+            return keyring.get_password(KEYRING_SERVICE, server_id)
+        except keyring.errors.KeyringError:
+            return None

--- a/gui/xrayebator_gui/core/servers.py
+++ b/gui/xrayebator_gui/core/servers.py
@@ -7,6 +7,9 @@
 from __future__ import annotations
 
 import json
+import os
+import stat
+import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,11 +40,22 @@ class ServerStore:
         return data if isinstance(data, list) else []
 
     def _save(self, servers: list[dict[str, Any]]) -> None:
-        tmp = self._path.with_suffix(".tmp")
-        tmp.write_text(
-            json.dumps(servers, ensure_ascii=False, indent=2), encoding="utf-8"
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self._path.name}.",
+            dir=self._dir,
         )
-        tmp.replace(self._path)
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                fd = -1
+                json.dump(servers, stream, ensure_ascii=False, indent=2)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(tmp_name, self._path)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            Path(tmp_name).unlink(missing_ok=True)
 
     def list(self) -> list[dict[str, Any]]:
         """Все серверы."""

--- a/gui/xrayebator_gui/core/ssh.py
+++ b/gui/xrayebator_gui/core/ssh.py
@@ -83,9 +83,7 @@ class SSHClient:
                 port=port,
                 username=user,
                 password=password if not key_path else None,
-                key_filename=(
-                    str(Path(key_path).expanduser()) if key_path else None
-                ),
+                key_filename=(str(Path(key_path).expanduser()) if key_path else None),
                 timeout=timeout,
                 banner_timeout=timeout,
                 auth_timeout=timeout,
@@ -94,7 +92,9 @@ class SSHClient:
             )
         except paramiko.AuthenticationException as e:
             client.close()
-            raise SSHAuthError(f"Аутентификация не удалась для {user}@{host}: {e}") from e
+            raise SSHAuthError(
+                f"Аутентификация не удалась для {user}@{host}: {e}"
+            ) from e
         except paramiko.SSHException as e:
             client.close()
             msg = str(e)

--- a/gui/xrayebator_gui/core/ssh.py
+++ b/gui/xrayebator_gui/core/ssh.py
@@ -1,0 +1,216 @@
+"""Обёртка над paramiko: подключение, стриминг команд, SFTP, sudo.
+
+Host key policy — TOFU: свой known_hosts в каталоге данных приложения.
+При смене ключа хоста бросается HostKeyChanged.
+"""
+
+from __future__ import annotations
+
+import shlex
+import socket
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+import paramiko
+from platformdirs import user_data_dir
+
+APP_NAME = "xrayebator-gui"
+
+
+class SSHError(Exception):
+    """Базовая ошибка SSH-слоя."""
+
+
+class SSHAuthError(SSHError):
+    """Ошибка аутентификации (пароль/ключ)."""
+
+
+class HostKeyChanged(SSHError):
+    """Ключ хоста изменился по сравнению с сохранённым (возможный MITM)."""
+
+
+def default_known_hosts() -> Path:
+    """Путь к known_hosts приложения (TOFU)."""
+    d = Path(user_data_dir(APP_NAME))
+    d.mkdir(parents=True, exist_ok=True)
+    return d / "known_hosts"
+
+
+class _TOFUHostKeyPolicy(paramiko.client.MissingHostKeyPolicy):
+    """Trust On First Use: новый ключ сохраняется, изменённый — ошибка."""
+
+    def __init__(self, known_hosts: Path):
+        self._path = known_hosts
+
+    def missing_host_key(self, client, hostname, key):
+        # Сюда попадаем только если ключа нет в known_hosts вообще —
+        # paramiko сам бросит RejectKey/SSHException при несовпадении.
+        client._host_keys.add(hostname, key.get_name(), key)  # noqa: SLF001
+        client.save_host_keys(str(self._path))
+
+
+class SSHClient:
+    """Тонкая обёртка над paramiko.SSHClient."""
+
+    def __init__(self, known_hosts: Optional[Path] = None):
+        self._client: Optional[paramiko.SSHClient] = None
+        self._known_hosts = known_hosts or default_known_hosts()
+        self._sudo_password: Optional[str] = None
+        self._need_sudo = False
+
+    def connect(
+        self,
+        host: str,
+        port: int = 22,
+        user: str = "root",
+        password: Optional[str] = None,
+        key_path: Optional[str] = None,
+        sudo_password: Optional[str] = None,
+        timeout: float = 15.0,
+    ) -> None:
+        """Подключиться к серверу. TOFU для host key."""
+        client = paramiko.SSHClient()
+        try:
+            client.load_host_keys(str(self._known_hosts))
+        except (OSError, paramiko.SSHException):
+            # Повреждённый known_hosts — начинаем с чистого листа.
+            pass
+        client.set_missing_host_key_policy(_TOFUHostKeyPolicy(self._known_hosts))
+        try:
+            client.connect(
+                hostname=host,
+                port=port,
+                username=user,
+                password=password if not key_path else None,
+                key_filename=(
+                    str(Path(key_path).expanduser()) if key_path else None
+                ),
+                timeout=timeout,
+                banner_timeout=timeout,
+                auth_timeout=timeout,
+                look_for_keys=False,
+                allow_agent=False,
+            )
+        except paramiko.AuthenticationException as e:
+            client.close()
+            raise SSHAuthError(f"Аутентификация не удалась для {user}@{host}: {e}") from e
+        except paramiko.SSHException as e:
+            client.close()
+            msg = str(e)
+            # Изменившийся ключ хоста paramiko сообщает как SSHException.
+            if "not found in known_hosts" not in msg and (
+                "host key" in msg.lower() or "mismatch" in msg.lower()
+            ):
+                raise HostKeyChanged(
+                    f"Ключ хоста {host} изменился! Возможна атака MITM.\n"
+                    f"Если сервер переустанавливался — удалите запись в {self._known_hosts}"
+                ) from e
+            raise SSHError(f"SSH-ошибка при подключении к {host}:{port}: {e}") from e
+        except (socket.timeout, TimeoutError, OSError) as e:
+            client.close()
+            raise SSHError(f"Не удалось подключиться к {host}:{port}: {e}") from e
+
+        self._client = client
+        self._need_sudo = user != "root"
+        self._sudo_password = sudo_password or password
+
+    @property
+    def connected(self) -> bool:
+        return self._client is not None
+
+    def _wrap_sudo(self, command: str) -> tuple[str, Optional[str]]:
+        """Обернуть команду в sudo, если пользователь не root.
+
+        Возвращает (команда, пароль_для_stdin или None).
+        """
+        if not self._need_sudo:
+            return command, None
+        if self._sudo_password is None:
+            return f"sudo -n bash -c {shlex.quote(command)}", None
+        wrapped = f"sudo -S -p '' bash -c {shlex.quote(command)}"
+        return wrapped, self._sudo_password
+
+    def run_streaming(
+        self,
+        command: str,
+        on_line: Optional[Callable[[str], None]] = None,
+        timeout: Optional[float] = 600.0,
+        *,
+        privileged: bool = True,
+    ) -> int:
+        """Выполнить команду, построчно стримя stdout+stderr в on_line.
+
+        Возвращает exit code.
+        """
+        if self._client is None:
+            raise SSHError("SSHClient не подключён")
+        if privileged:
+            cmd, sudo_pw = self._wrap_sudo(command)
+        else:
+            cmd, sudo_pw = command, None
+        chan = self._client.get_transport().open_session(timeout=timeout)  # type: ignore[union-attr]
+        chan.set_combine_stderr(True)
+        chan.settimeout(timeout)
+        chan.exec_command(cmd)
+        if sudo_pw is not None:
+            chan.sendall(sudo_pw + "\n")
+        buf = b""
+        while True:
+            if chan.exit_status_ready() and not chan.recv_ready():
+                break
+            if chan.recv_ready():
+                data = chan.recv(4096)
+                if not data:
+                    break
+                buf += data
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    if on_line:
+                        on_line(line.decode("utf-8", errors="replace"))
+            elif chan.exit_status_ready():
+                break
+            else:
+                time.sleep(0.05)
+        # Дочитываем остаток после завершения канала.
+        while chan.recv_ready():
+            data = chan.recv(4096)
+            if not data:
+                break
+            buf += data
+        if buf and on_line:
+            for line in buf.split(b"\n"):
+                on_line(line.decode("utf-8", errors="replace"))
+        return chan.recv_exit_status()
+
+    def run(
+        self,
+        command: str,
+        timeout: Optional[float] = 60.0,
+        *,
+        privileged: bool = True,
+    ) -> tuple[int, str]:
+        """Выполнить команду и вернуть (exit code, весь вывод)."""
+        out: list[str] = []
+        rc = self.run_streaming(
+            command,
+            on_line=out.append,
+            timeout=timeout,
+            privileged=privileged,
+        )
+        return rc, "\n".join(out)
+
+    def upload(self, local_path: str | Path, remote_path: str) -> None:
+        """Загрузить файл на сервер через SFTP."""
+        if self._client is None:
+            raise SSHError("SSHClient не подключён")
+        sftp = self._client.open_sftp()
+        try:
+            sftp.put(str(local_path), remote_path)
+        finally:
+            sftp.close()
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None

--- a/gui/xrayebator_gui/core/subscription.py
+++ b/gui/xrayebator_gui/core/subscription.py
@@ -1,0 +1,139 @@
+"""Загрузка и разбор подписки Xrayebator (список vless:// ссылок).
+
+Сервер отдаёт либо plain-text список ссылок (HAPP), либо base64 от него
+(v2rayNG) — определяем по содержимому.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import re
+from dataclasses import dataclass
+from urllib.parse import parse_qs, unquote, urlparse
+
+import requests
+
+
+class SubscriptionError(Exception):
+    """Ошибка загрузки или разбора подписки."""
+
+
+@dataclass
+class VlessLink:
+    """Разобранная vless:// ссылка."""
+
+    raw: str
+    address: str
+    port: int
+    uuid: str
+    network: str = "tcp"          # tcp / grpc / xhttp
+    security: str = ""
+    sni: str = ""
+    fingerprint: str = ""         # fp
+    public_key: str = ""          # pbk
+    short_id: str = ""            # sid
+    flow: str = ""
+    path: str = ""
+    host: str = ""
+    service_name: str = ""        # grpc serviceName
+    encryption: str = "none"
+    remark: str = ""
+
+    @property
+    def label(self) -> str:
+        """Короткая метка маршрута для UI: transport:port."""
+        flow = f"+{self.flow}" if self.flow else ""
+        return f"{self.network}{flow}:{self.port}"
+
+
+def fetch(url: str, timeout: float = 20.0) -> str:
+    """Скачать тело подписки. TLS-сертификат Let's Encrypt — verify=True."""
+    try:
+        resp = requests.get(url, timeout=timeout, verify=True)
+        resp.raise_for_status()
+    except requests.exceptions.SSLError as e:
+        raise SubscriptionError(f"Ошибка TLS при загрузке подписки: {e}") from e
+    except requests.exceptions.Timeout as e:
+        raise SubscriptionError(f"Таймаут загрузки подписки ({timeout} с)") from e
+    except requests.exceptions.HTTPError as e:
+        raise SubscriptionError(f"Сервер подписки ответил ошибкой: {e}") from e
+    except requests.exceptions.RequestException as e:
+        raise SubscriptionError(f"Не удалось загрузить подписку: {e}") from e
+    return resp.text
+
+
+def _try_base64(body: str) -> str | None:
+    """Попытаться декодировать тело как base64; вернуть текст или None."""
+    compact = re.sub(r"\s+", "", body)
+    if not compact:
+        return None
+    try:
+        decoded = base64.b64decode(compact, validate=True)
+        text = decoded.decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+    return text if "vless://" in text else None
+
+
+def parse(body: str) -> list[VlessLink]:
+    """Разобрать тело подписки в список VlessLink.
+
+    Строки без vless:// (служебные строки HAPP, комментарии) игнорируются.
+    """
+    decoded = _try_base64(body)
+    if decoded is not None:
+        body = decoded
+
+    links: list[VlessLink] = []
+    for line in body.splitlines():
+        line = line.strip()
+        if not line.startswith("vless://"):
+            continue
+        link = _parse_vless(line)
+        if link is not None:
+            links.append(link)
+    return links
+
+
+def _parse_vless(url: str) -> VlessLink | None:
+    """Разобрать одну vless:// ссылку."""
+    try:
+        u = urlparse(url)
+    except ValueError:
+        return None
+    if not u.username or not u.hostname:
+        return None
+    q = {k: v[0] for k, v in parse_qs(u.query).items()}
+    try:
+        port = u.port or 443
+    except ValueError:
+        return None
+    return VlessLink(
+        raw=url,
+        address=u.hostname,
+        port=port,
+        uuid=unquote(u.username),
+        network=q.get("type", "tcp"),
+        security=q.get("security", ""),
+        sni=q.get("sni", ""),
+        fingerprint=q.get("fp", ""),
+        public_key=q.get("pbk", ""),
+        short_id=q.get("sid", ""),
+        flow=q.get("flow", ""),
+        path=unquote(q.get("path", "")),
+        host=q.get("host", ""),
+        service_name=q.get("serviceName", ""),
+        encryption=q.get("encryption", "none"),
+        remark=unquote(u.fragment or ""),
+    )
+
+
+def pick_default(links: list[VlessLink]) -> VlessLink | None:
+    """Маршрут по умолчанию: первый tcp+vision, иначе просто первый."""
+    if not links:
+        return None
+    for link in links:
+        if link.network == "tcp" and link.flow == "xtls-rprx-vision":
+            return link
+    return links[0]

--- a/gui/xrayebator_gui/core/subscription.py
+++ b/gui/xrayebator_gui/core/subscription.py
@@ -53,13 +53,16 @@ def fetch(url: str, timeout: float = 20.0) -> str:
         resp = requests.get(url, timeout=timeout, verify=True)
         resp.raise_for_status()
     except requests.exceptions.SSLError as e:
-        raise SubscriptionError(f"Ошибка TLS при загрузке подписки: {e}") from e
+        raise SubscriptionError("Ошибка TLS при загрузке подписки") from e
     except requests.exceptions.Timeout as e:
         raise SubscriptionError(f"Таймаут загрузки подписки ({timeout} с)") from e
     except requests.exceptions.HTTPError as e:
-        raise SubscriptionError(f"Сервер подписки ответил ошибкой: {e}") from e
+        status = e.response.status_code if e.response is not None else "?"
+        raise SubscriptionError(f"Сервер подписки ответил HTTP {status}") from e
     except requests.exceptions.RequestException as e:
-        raise SubscriptionError(f"Не удалось загрузить подписку: {e}") from e
+        raise SubscriptionError(
+            f"Не удалось загрузить подписку ({type(e).__name__})"
+        ) from e
     return resp.text
 
 

--- a/gui/xrayebator_gui/core/subscription.py
+++ b/gui/xrayebator_gui/core/subscription.py
@@ -12,8 +12,6 @@ import re
 from dataclasses import dataclass
 from urllib.parse import parse_qs, unquote, urlparse
 
-import requests
-
 
 class SubscriptionError(Exception):
     """Ошибка загрузки или разбора подписки."""
@@ -49,6 +47,8 @@ class VlessLink:
 
 def fetch(url: str, timeout: float = 20.0) -> str:
     """Скачать тело подписки. TLS-сертификат Let's Encrypt — verify=True."""
+    import requests
+
     try:
         resp = requests.get(url, timeout=timeout, verify=True)
         resp.raise_for_status()

--- a/gui/xrayebator_gui/core/subscription.py
+++ b/gui/xrayebator_gui/core/subscription.py
@@ -27,16 +27,16 @@ class VlessLink:
     address: str
     port: int
     uuid: str
-    network: str = "tcp"          # tcp / grpc / xhttp
+    network: str = "tcp"  # tcp / grpc / xhttp
     security: str = ""
     sni: str = ""
-    fingerprint: str = ""         # fp
-    public_key: str = ""          # pbk
-    short_id: str = ""            # sid
+    fingerprint: str = ""  # fp
+    public_key: str = ""  # pbk
+    short_id: str = ""  # sid
     flow: str = ""
     path: str = ""
     host: str = ""
-    service_name: str = ""        # grpc serviceName
+    service_name: str = ""  # grpc serviceName
     encryption: str = "none"
     remark: str = ""
 
@@ -90,13 +90,13 @@ def parse(body: str) -> list[VlessLink]:
         line = line.strip()
         if not line.startswith("vless://"):
             continue
-        link = _parse_vless(line)
+        link = parse_link(line)
         if link is not None:
             links.append(link)
     return links
 
 
-def _parse_vless(url: str) -> VlessLink | None:
+def parse_link(url: str) -> VlessLink | None:
     """Разобрать одну vless:// ссылку."""
     try:
         u = urlparse(url)

--- a/gui/xrayebator_gui/core/xray.py
+++ b/gui/xrayebator_gui/core/xray.py
@@ -1,0 +1,438 @@
+"""Менеджер локального xray-core: бинарник, конфиг, процесс, health-check."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+import requests
+from platformdirs import user_data_dir
+
+from .subscription import VlessLink
+
+APP_NAME = "xrayebator-gui"
+XRAY_REPO = "XTLS/Xray-core"
+# Stable v26.3.27 predates desktop auto-routing. This pinned prerelease contains
+# gateway/dns/autoSystemRoutingTable/autoOutboundsInterface plus Wintun naming.
+XRAY_TUN_VERSION = "v26.7.28"
+SOCKS_PORT = 10808
+HTTP_PORT = 10809
+
+# Ассет релиза Xray-core для каждой платформы
+_PLATFORM_ASSETS = {
+    ("Windows", "AMD64"): "Xray-windows-64.zip",
+    ("Windows", "x86_64"): "Xray-windows-64.zip",
+    ("Linux", "x86_64"): "Xray-linux-64.zip",
+    ("Linux", "aarch64"): "Xray-linux-arm64-v8a.zip",
+    ("Darwin", "x86_64"): "Xray-macos-64.zip",
+    ("Darwin", "arm64"): "Xray-macos-arm64-v8a.zip",
+}
+
+
+class XrayError(Exception):
+    """Ошибка менеджера xray-core."""
+
+
+def data_dir() -> Path:
+    d = Path(user_data_dir(APP_NAME))
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def bin_dir() -> Path:
+    d = data_dir() / "bin"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def xray_binary_name() -> str:
+    return "xray.exe" if platform.system() == "Windows" else "xray"
+
+
+def xray_binary_path() -> Path:
+    return bin_dir() / xray_binary_name()
+
+
+def _vendor_dir() -> Path:
+    # gui/xrayebator_gui/core/xray.py -> repo/gui/vendor
+    return Path(__file__).resolve().parents[2] / "vendor"
+
+
+def _platform_asset() -> str:
+    key = (platform.system(), platform.machine())
+    asset = _PLATFORM_ASSETS.get(key)
+    if asset is None:
+        raise XrayError(f"Неподдерживаемая платформа для xray-core: {key}")
+    return asset
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _parse_dgst(dgst_text: str, asset_name: str) -> Optional[str]:
+    """Извлечь sha256 ассета из файла .dgst релиза Xray-core."""
+    for line in dgst_text.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[-1].endswith(asset_name):
+            return parts[0].strip()
+    return None
+
+
+def _extract_member(
+    zf: zipfile.ZipFile, member: str, dest: Path, *, executable: bool = False
+) -> None:
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{dest.name}.", dir=dest.parent)
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        with zf.open(member) as src, open(tmp, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        if executable:
+            tmp.chmod(
+                tmp.stat().st_mode
+                | stat.S_IXUSR
+                | stat.S_IXGRP
+                | stat.S_IXOTH
+            )
+        os.replace(tmp, dest)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _install_from_zip(zip_path: Path, dest: Path) -> None:
+    """Atomically install Xray and the Windows TUN runtime from an archive."""
+    wanted = xray_binary_name()
+    with zipfile.ZipFile(zip_path) as zf:
+        member = next(
+            (n for n in zf.namelist() if n.endswith(wanted) or n.endswith("xray")),
+            None,
+        )
+        if member is None:
+            raise XrayError(f"В архиве {zip_path.name} не найден бинарник xray")
+        _extract_member(
+            zf,
+            member,
+            dest,
+            executable=platform.system() != "Windows",
+        )
+
+        if platform.system() == "Windows":
+            wintun_member = next(
+                (n for n in zf.namelist() if n.lower().endswith("wintun.dll")),
+                None,
+            )
+            if wintun_member is not None:
+                _extract_member(zf, wintun_member, dest.parent / "wintun.dll")
+
+
+def _installed_version(binary: Path) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            [str(binary), "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    match = re.search(r"\bXray\s+(\d+\.\d+\.\d+)\b", result.stdout)
+    return f"v{match.group(1)}" if match else None
+
+
+def ensure_binary(version: Optional[str] = None) -> Path:
+    """Убедиться, что бинарник xray есть; вернуть путь к нему.
+
+    Порядок: уже скачан -> vendor/ -> скачать релиз с GitHub (с проверкой
+    sha256 по .dgst).
+    """
+    tag = version or XRAY_TUN_VERSION
+    dest = xray_binary_path()
+    if dest.exists() and _installed_version(dest) == tag:
+        return dest
+
+    asset = _platform_asset()
+    vendor_zip = _vendor_dir() / asset
+    if vendor_zip.exists():
+        _install_from_zip(vendor_zip, dest)
+        installed = _installed_version(dest)
+        if installed == tag:
+            return dest
+        raise XrayError(
+            f"Vendor Xray имеет версию {installed or '?'}, требуется {tag}"
+        )
+
+    base = f"https://github.com/{XRAY_REPO}/releases/download/{tag}"
+    tmp = Path(tempfile.mkdtemp(prefix="xray-dl-"))
+    try:
+        zip_path = tmp / asset
+        _download(f"{base}/{asset}", zip_path)
+        dgst_path = tmp / f"{asset}.dgst"
+        _download(f"{base}/{asset}.dgst", dgst_path)
+        expected = _parse_dgst(dgst_path.read_text(encoding="utf-8"), asset)
+        if expected is None:
+            raise XrayError(f"Не найден sha256 для {asset} в .dgst")
+        actual = _sha256(zip_path)
+        if actual.lower() != expected.lower():
+            raise XrayError(
+                f"sha256 не совпал для {asset}: {actual} != {expected}"
+            )
+        _install_from_zip(zip_path, dest)
+        installed = _installed_version(dest)
+        if installed != tag:
+            raise XrayError(
+                f"Установлен Xray {installed or '?'}, ожидался {tag}"
+            )
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+    return dest
+
+
+def _download(url: str, dest: Path) -> None:
+    with requests.get(url, stream=True, timeout=120) as resp:
+        resp.raise_for_status()
+        with open(dest, "wb") as f:
+            for chunk in resp.iter_content(1 << 20):
+                f.write(chunk)
+
+
+def _build_outbounds(link: VlessLink) -> list[dict]:
+    user: dict = {"id": link.uuid, "encryption": link.encryption or "none"}
+    # flow несовместим с post-quantum encryption — добавляем только для "none"
+    if link.flow and (not link.encryption or link.encryption == "none"):
+        user["flow"] = link.flow
+
+    stream: dict = {
+        "network": link.network,
+        "security": "reality",
+        "realitySettings": {
+            "serverName": link.sni,
+            "fingerprint": link.fingerprint or "chrome",
+            "publicKey": link.public_key,
+            "shortId": link.short_id,
+        },
+    }
+    if link.network == "tcp":
+        stream["tcpSettings"] = {}
+    elif link.network == "grpc":
+        stream["grpcSettings"] = {"serviceName": link.service_name}
+    elif link.network == "xhttp":
+        xhttp: dict = {"mode": "auto"}
+        if link.path:
+            xhttp["path"] = link.path
+        if link.host:
+            xhttp["host"] = link.host
+        stream["xhttpSettings"] = xhttp
+
+    return [
+        {
+            "tag": "proxy",
+            "protocol": "vless",
+            "settings": {
+                "vnext": [
+                    {
+                        "address": link.address,
+                        "port": link.port,
+                        "users": [user],
+                    }
+                ]
+            },
+            "streamSettings": stream,
+        },
+        {"tag": "direct", "protocol": "freedom"},
+        {"tag": "block", "protocol": "blackhole"},
+    ]
+
+
+def _local_proxy_inbounds(
+    socks_port: int = SOCKS_PORT, http_port: int = HTTP_PORT
+) -> list[dict]:
+    return [
+        {
+            "tag": "socks-in",
+            "listen": "127.0.0.1",
+            "port": socks_port,
+            "protocol": "socks",
+            "settings": {"udp": True},
+            "sniffing": {
+                "enabled": True,
+                "destOverride": ["http", "tls"],
+            },
+        },
+        {
+            "tag": "http-in",
+            "listen": "127.0.0.1",
+            "port": http_port,
+            "protocol": "http",
+            "sniffing": {
+                "enabled": True,
+                "destOverride": ["http", "tls"],
+            },
+        },
+    ]
+
+
+def build_client_config(
+    link: VlessLink, socks_port: int = SOCKS_PORT, http_port: int = HTTP_PORT
+) -> dict:
+    """Build the current system-proxy client configuration."""
+    return {
+        "log": {"loglevel": "warning"},
+        "inbounds": _local_proxy_inbounds(socks_port, http_port),
+        "outbounds": _build_outbounds(link),
+    }
+
+
+def _default_tun_name(system: str) -> Optional[str]:
+    if system == "Windows":
+        return "xrayebator"
+    if system == "Linux":
+        return "xrayebator0"
+    # Darwin requires utunN and Xray can select a free random number.
+    if system == "Darwin":
+        return None
+    raise XrayError(f"TUN не поддерживается на платформе {system}")
+
+
+def build_tun_client_config(
+    link: VlessLink,
+    *,
+    system: Optional[str] = None,
+    interface_name: Optional[str] = None,
+    mtu: int = 1500,
+    ipv6: bool = True,
+    include_local_proxies: bool = False,
+) -> dict:
+    """Build a full-device Xray-native TUN configuration.
+
+    Linux/macOS DNS still requires the privileged platform adapter: Xray's
+    ``dns`` TUN setting only changes the Windows adapter.
+    """
+    if not 1280 <= mtu <= 9000:
+        raise XrayError(f"Некорректный TUN MTU: {mtu}")
+
+    detected_system = system or platform.system()
+    name = interface_name if interface_name is not None else _default_tun_name(
+        detected_system
+    )
+    routes = ["0.0.0.0/0"]
+    gateways = ["10.254.0.1/30"]
+    if ipv6:
+        routes.append("::/0")
+        gateways.append("fdfe:dcba:9876::1/126")
+
+    settings: dict = {
+        "mtu": mtu,
+        "gateway": gateways,
+        "userLevel": 0,
+        "autoSystemRoutingTable": routes,
+        "autoOutboundsInterface": "auto",
+    }
+    if name:
+        settings["name"] = name
+    if detected_system == "Windows":
+        settings["desc"] = "Xrayebator"
+        settings["dns"] = ["1.1.1.1", "8.8.8.8"]
+
+    inbounds = [
+        {
+            "tag": "tun-in",
+            "port": 0,
+            "protocol": "tun",
+            "settings": settings,
+            "sniffing": {
+                "enabled": True,
+                "destOverride": ["http", "tls", "quic"],
+                "routeOnly": True,
+            },
+        }
+    ]
+    if include_local_proxies:
+        inbounds.extend(_local_proxy_inbounds())
+
+    return {
+        "log": {"loglevel": "warning"},
+        "inbounds": inbounds,
+        "outbounds": _build_outbounds(link),
+    }
+
+
+class XrayProcess:
+    """Запуск/остановка локального xray-core."""
+
+    def __init__(self, binary: Optional[Path] = None):
+        self._binary = binary or xray_binary_path()
+        self._proc: Optional[subprocess.Popen] = None
+        self._config_path = data_dir() / "config.json"
+
+    def start(self, config: dict) -> None:
+        """Записать конфиг и запустить xray; детект раннего падения."""
+        if self.is_running():
+            self.stop()
+        if not self._binary.exists():
+            raise XrayError(
+                f"Бинарник xray не найден: {self._binary}. "
+                "Сначала вызовите ensure_binary()."
+            )
+        self._config_path.write_text(
+            json.dumps(config, indent=2), encoding="utf-8"
+        )
+        self._proc = subprocess.Popen(
+            [str(self._binary), "run", "-c", str(self._config_path)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        # Даём процессу шанс упасть сразу (битый конфиг и т.п.)
+        time.sleep(1.0)
+        if self._proc.poll() is not None:
+            stderr = (self._proc.stderr.read() if self._proc.stderr else "")[:2000]
+            self._proc = None
+            raise XrayError(f"xray завершился сразу после старта:\n{stderr}")
+
+    def stop(self) -> None:
+        if self._proc is None:
+            return
+        self._proc.terminate()
+        try:
+            self._proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait(timeout=5)
+        self._proc = None
+
+    def is_running(self) -> bool:
+        return self._proc is not None and self._proc.poll() is None
+
+    def health_check(self, socks_port: int = SOCKS_PORT, timeout: float = 10.0) -> Optional[str]:
+        """Проверить туннель: запрос api.ipify.org через SOCKS5.
+
+        Возвращает внешний IP или None.
+        """
+        proxy = f"socks5h://127.0.0.1:{socks_port}"
+        try:
+            resp = requests.get(
+                "https://api.ipify.org",
+                proxies={"http": proxy, "https": proxy},
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            return resp.text.strip()
+        except requests.RequestException:
+            return None

--- a/gui/xrayebator_gui/core/xray.py
+++ b/gui/xrayebator_gui/core/xray.py
@@ -466,7 +466,13 @@ class XrayProcess:
             Path(tmp_name).unlink(missing_ok=True)
 
         self._stderr_path.parent.mkdir(parents=True, exist_ok=True)
-        self._stderr_file = open(self._stderr_path, "w+b")
+        stderr_fd = os.open(
+            self._stderr_path,
+            os.O_RDWR | os.O_CREAT | os.O_TRUNC,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        os.fchmod(stderr_fd, stat.S_IRUSR | stat.S_IWUSR)
+        self._stderr_file = os.fdopen(stderr_fd, "w+b")
         self._proc = subprocess.Popen(
             [str(self._binary), "run", "-c", str(self._config_path)],
             stdout=subprocess.DEVNULL,

--- a/gui/xrayebator_gui/core/xray.py
+++ b/gui/xrayebator_gui/core/xray.py
@@ -15,9 +15,8 @@ import time
 import zipfile
 from pathlib import Path
 from typing import Optional
-
-import requests
-from platformdirs import user_data_dir
+from urllib.error import URLError
+from urllib.request import ProxyHandler, build_opener
 
 from .subscription import VlessLink
 
@@ -45,6 +44,8 @@ class XrayError(Exception):
 
 
 def data_dir() -> Path:
+    from platformdirs import user_data_dir
+
     d = Path(user_data_dir(APP_NAME))
     d.mkdir(parents=True, exist_ok=True)
     return d
@@ -203,6 +204,8 @@ def ensure_binary(version: Optional[str] = None) -> Path:
 
 
 def _download(url: str, dest: Path) -> None:
+    import requests
+
     with requests.get(url, stream=True, timeout=120) as resp:
         resp.raise_for_status()
         with open(dest, "wb") as f:
@@ -472,6 +475,8 @@ class XrayProcess:
 
         Возвращает внешний IP или None.
         """
+        import requests
+
         proxy = f"socks5h://127.0.0.1:{socks_port}"
         session = requests.Session()
         session.trust_env = False
@@ -488,11 +493,9 @@ class XrayProcess:
 
     def health_check_tun(self, timeout: float = 10.0) -> Optional[str]:
         """Проверить полный системный маршрут без локального proxy."""
-        session = requests.Session()
-        session.trust_env = False
         try:
-            resp = session.get("https://api.ipify.org", timeout=timeout)
-            resp.raise_for_status()
-            return resp.text.strip()
-        except requests.RequestException:
+            opener = build_opener(ProxyHandler({}))
+            with opener.open("https://api.ipify.org", timeout=timeout) as response:
+                return response.read(128).decode("ascii").strip()
+        except (OSError, UnicodeError, URLError):
             return None

--- a/gui/xrayebator_gui/core/xray.py
+++ b/gui/xrayebator_gui/core/xray.py
@@ -88,9 +88,18 @@ def _sha256(path: Path) -> str:
 def _parse_dgst(dgst_text: str, asset_name: str) -> Optional[str]:
     """Извлечь sha256 ассета из файла .dgst релиза Xray-core."""
     for line in dgst_text.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip().upper() == "SHA2-256":
+            digest = value.strip()
+            if re.fullmatch(r"[0-9a-fA-F]{64}", digest):
+                return digest
         parts = line.split()
-        if len(parts) >= 2 and parts[-1].endswith(asset_name):
-            return parts[0].strip()
+        if (
+            len(parts) >= 2
+            and parts[-1].endswith(asset_name)
+            and re.fullmatch(r"[0-9a-fA-F]{64}", parts[0])
+        ):
+            return parts[0]
     return None
 
 
@@ -104,12 +113,7 @@ def _extract_member(
         with zf.open(member) as src, open(tmp, "wb") as dst:
             shutil.copyfileobj(src, dst)
         if executable:
-            tmp.chmod(
-                tmp.stat().st_mode
-                | stat.S_IXUSR
-                | stat.S_IXGRP
-                | stat.S_IXOTH
-            )
+            tmp.chmod(tmp.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         os.replace(tmp, dest)
     finally:
         tmp.unlink(missing_ok=True)
@@ -174,9 +178,7 @@ def ensure_binary(version: Optional[str] = None) -> Path:
         installed = _installed_version(dest)
         if installed == tag:
             return dest
-        raise XrayError(
-            f"Vendor Xray имеет версию {installed or '?'}, требуется {tag}"
-        )
+        raise XrayError(f"Vendor Xray имеет версию {installed or '?'}, требуется {tag}")
 
     base = f"https://github.com/{XRAY_REPO}/releases/download/{tag}"
     tmp = Path(tempfile.mkdtemp(prefix="xray-dl-"))
@@ -190,15 +192,11 @@ def ensure_binary(version: Optional[str] = None) -> Path:
             raise XrayError(f"Не найден sha256 для {asset} в .dgst")
         actual = _sha256(zip_path)
         if actual.lower() != expected.lower():
-            raise XrayError(
-                f"sha256 не совпал для {asset}: {actual} != {expected}"
-            )
+            raise XrayError(f"sha256 не совпал для {asset}: {actual} != {expected}")
         _install_from_zip(zip_path, dest)
         installed = _installed_version(dest)
         if installed != tag:
-            raise XrayError(
-                f"Установлен Xray {installed or '?'}, ожидался {tag}"
-            )
+            raise XrayError(f"Установлен Xray {installed or '?'}, ожидался {tag}")
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     return dest
@@ -212,7 +210,9 @@ def _download(url: str, dest: Path) -> None:
                 f.write(chunk)
 
 
-def _build_outbounds(link: VlessLink) -> list[dict]:
+def _build_outbounds(
+    link: VlessLink, *, outbound_mark: Optional[int] = None
+) -> list[dict]:
     user: dict = {"id": link.uuid, "encryption": link.encryption or "none"}
     # flow несовместим с post-quantum encryption — добавляем только для "none"
     if link.flow and (not link.encryption or link.encryption == "none"):
@@ -239,23 +239,34 @@ def _build_outbounds(link: VlessLink) -> list[dict]:
         if link.host:
             xhttp["host"] = link.host
         stream["xhttpSettings"] = xhttp
+    if outbound_mark is not None:
+        if not 1 <= outbound_mark <= 0xFFFFFFFF:
+            raise XrayError(f"Некорректная метка outbound: {outbound_mark}")
+        stream["sockopt"] = {"mark": outbound_mark}
 
-    return [
-        {
-            "tag": "proxy",
-            "protocol": "vless",
-            "settings": {
-                "vnext": [
-                    {
-                        "address": link.address,
-                        "port": link.port,
-                        "users": [user],
-                    }
-                ]
-            },
-            "streamSettings": stream,
+    proxy_outbound = {
+        "tag": "proxy",
+        "protocol": "vless",
+        "settings": {
+            "vnext": [
+                {
+                    "address": link.address,
+                    "port": link.port,
+                    "users": [user],
+                }
+            ]
         },
-        {"tag": "direct", "protocol": "freedom"},
+        "streamSettings": stream,
+    }
+    direct_outbound: dict = {
+        "tag": "direct",
+        "protocol": "freedom",
+    }
+    if outbound_mark is not None:
+        direct_outbound["streamSettings"] = {"sockopt": {"mark": outbound_mark}}
+    return [
+        proxy_outbound,
+        direct_outbound,
         {"tag": "block", "protocol": "blackhole"},
     ]
 
@@ -318,6 +329,7 @@ def build_tun_client_config(
     mtu: int = 1500,
     ipv6: bool = True,
     include_local_proxies: bool = False,
+    outbound_mark: Optional[int] = None,
 ) -> dict:
     """Build a full-device Xray-native TUN configuration.
 
@@ -328,8 +340,10 @@ def build_tun_client_config(
         raise XrayError(f"Некорректный TUN MTU: {mtu}")
 
     detected_system = system or platform.system()
-    name = interface_name if interface_name is not None else _default_tun_name(
-        detected_system
+    name = (
+        interface_name
+        if interface_name is not None
+        else _default_tun_name(detected_system)
     )
     routes = ["0.0.0.0/0"]
     gateways = ["10.254.0.1/30"]
@@ -369,17 +383,25 @@ def build_tun_client_config(
     return {
         "log": {"loglevel": "warning"},
         "inbounds": inbounds,
-        "outbounds": _build_outbounds(link),
+        "outbounds": _build_outbounds(link, outbound_mark=outbound_mark),
     }
 
 
 class XrayProcess:
     """Запуск/остановка локального xray-core."""
 
-    def __init__(self, binary: Optional[Path] = None):
+    def __init__(
+        self,
+        binary: Optional[Path] = None,
+        *,
+        config_path: Optional[Path] = None,
+        stderr_path: Optional[Path] = None,
+    ):
         self._binary = binary or xray_binary_path()
         self._proc: Optional[subprocess.Popen] = None
-        self._config_path = data_dir() / "config.json"
+        self._config_path = config_path or data_dir() / "config.json"
+        self._stderr_path = stderr_path or data_dir() / "xray.log"
+        self._stderr_file = None
 
     def start(self, config: dict) -> None:
         """Записать конфиг и запустить xray; детект раннего падения."""
@@ -390,19 +412,39 @@ class XrayProcess:
                 f"Бинарник xray не найден: {self._binary}. "
                 "Сначала вызовите ensure_binary()."
             )
-        self._config_path.write_text(
-            json.dumps(config, indent=2), encoding="utf-8"
+        self._config_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self._config_path.name}.",
+            dir=self._config_path.parent,
         )
+        try:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            with os.fdopen(fd, "w", encoding="utf-8") as config_file:
+                fd = -1
+                json.dump(config, config_file, indent=2)
+                config_file.flush()
+                os.fsync(config_file.fileno())
+            os.replace(tmp_name, self._config_path)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            Path(tmp_name).unlink(missing_ok=True)
+
+        self._stderr_path.parent.mkdir(parents=True, exist_ok=True)
+        self._stderr_file = open(self._stderr_path, "w+b")
         self._proc = subprocess.Popen(
             [str(self._binary), "run", "-c", str(self._config_path)],
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-            text=True,
+            stderr=self._stderr_file,
         )
         # Даём процессу шанс упасть сразу (битый конфиг и т.п.)
         time.sleep(1.0)
         if self._proc.poll() is not None:
-            stderr = (self._proc.stderr.read() if self._proc.stderr else "")[:2000]
+            self._stderr_file.flush()
+            self._stderr_file.seek(0)
+            stderr = self._stderr_file.read(2000).decode("utf-8", errors="replace")
+            self._stderr_file.close()
+            self._stderr_file = None
             self._proc = None
             raise XrayError(f"xray завершился сразу после старта:\n{stderr}")
 
@@ -416,22 +458,40 @@ class XrayProcess:
             self._proc.kill()
             self._proc.wait(timeout=5)
         self._proc = None
+        if self._stderr_file is not None:
+            self._stderr_file.close()
+            self._stderr_file = None
 
     def is_running(self) -> bool:
         return self._proc is not None and self._proc.poll() is None
 
-    def health_check(self, socks_port: int = SOCKS_PORT, timeout: float = 10.0) -> Optional[str]:
+    def health_check(
+        self, socks_port: int = SOCKS_PORT, timeout: float = 10.0
+    ) -> Optional[str]:
         """Проверить туннель: запрос api.ipify.org через SOCKS5.
 
         Возвращает внешний IP или None.
         """
         proxy = f"socks5h://127.0.0.1:{socks_port}"
+        session = requests.Session()
+        session.trust_env = False
         try:
-            resp = requests.get(
+            resp = session.get(
                 "https://api.ipify.org",
                 proxies={"http": proxy, "https": proxy},
                 timeout=timeout,
             )
+            resp.raise_for_status()
+            return resp.text.strip()
+        except requests.RequestException:
+            return None
+
+    def health_check_tun(self, timeout: float = 10.0) -> Optional[str]:
+        """Проверить полный системный маршрут без локального proxy."""
+        session = requests.Session()
+        session.trust_env = False
+        try:
+            resp = session.get("https://api.ipify.org", timeout=timeout)
             resp.raise_for_status()
             return resp.text.strip()
         except requests.RequestException:

--- a/gui/xrayebator_gui/core/xray.py
+++ b/gui/xrayebator_gui/core/xray.py
@@ -18,6 +18,7 @@ from typing import Optional
 from urllib.error import URLError
 from urllib.request import ProxyHandler, build_opener
 
+from .routing import RoutingProfile, build_routing_config
 from .subscription import VlessLink
 
 APP_NAME = "xrayebator-gui"
@@ -121,7 +122,7 @@ def _extract_member(
 
 
 def _install_from_zip(zip_path: Path, dest: Path) -> None:
-    """Atomically install Xray and the Windows TUN runtime from an archive."""
+    """Atomically install Xray, routing data and the Windows TUN runtime."""
     wanted = xray_binary_name()
     with zipfile.ZipFile(zip_path) as zf:
         member = next(
@@ -136,6 +137,14 @@ def _install_from_zip(zip_path: Path, dest: Path) -> None:
             dest,
             executable=platform.system() != "Windows",
         )
+        for resource in ("geoip.dat", "geosite.dat"):
+            resource_member = next(
+                (n for n in zf.namelist() if n.lower().endswith(resource)),
+                None,
+            )
+            if resource_member is None:
+                raise XrayError(f"В архиве {zip_path.name} не найден {resource}")
+            _extract_member(zf, resource_member, dest.parent / resource)
 
         if platform.system() == "Windows":
             wintun_member = next(
@@ -161,6 +170,13 @@ def _installed_version(binary: Path) -> Optional[str]:
     return f"v{match.group(1)}" if match else None
 
 
+def _routing_data_installed(binary: Path) -> bool:
+    return all(
+        (binary.parent / resource).is_file()
+        for resource in ("geoip.dat", "geosite.dat")
+    )
+
+
 def ensure_binary(version: Optional[str] = None) -> Path:
     """Убедиться, что бинарник xray есть; вернуть путь к нему.
 
@@ -169,7 +185,11 @@ def ensure_binary(version: Optional[str] = None) -> Path:
     """
     tag = version or XRAY_TUN_VERSION
     dest = xray_binary_path()
-    if dest.exists() and _installed_version(dest) == tag:
+    if (
+        dest.exists()
+        and _installed_version(dest) == tag
+        and _routing_data_installed(dest)
+    ):
         return dest
 
     asset = _platform_asset()
@@ -303,14 +323,21 @@ def _local_proxy_inbounds(
 
 
 def build_client_config(
-    link: VlessLink, socks_port: int = SOCKS_PORT, http_port: int = HTTP_PORT
+    link: VlessLink,
+    socks_port: int = SOCKS_PORT,
+    http_port: int = HTTP_PORT,
+    routing_profile: RoutingProfile = RoutingProfile.FULL,
 ) -> dict:
     """Build the current system-proxy client configuration."""
-    return {
+    config = {
         "log": {"loglevel": "warning"},
         "inbounds": _local_proxy_inbounds(socks_port, http_port),
         "outbounds": _build_outbounds(link),
     }
+    routing = build_routing_config(routing_profile)
+    if routing is not None:
+        config["routing"] = routing
+    return config
 
 
 def _default_tun_name(system: str) -> Optional[str]:
@@ -333,6 +360,7 @@ def build_tun_client_config(
     ipv6: bool = True,
     include_local_proxies: bool = False,
     outbound_mark: Optional[int] = None,
+    routing_profile: RoutingProfile = RoutingProfile.FULL,
 ) -> dict:
     """Build a full-device Xray-native TUN configuration.
 
@@ -383,11 +411,15 @@ def build_tun_client_config(
     if include_local_proxies:
         inbounds.extend(_local_proxy_inbounds())
 
-    return {
+    config = {
         "log": {"loglevel": "warning"},
         "inbounds": inbounds,
         "outbounds": _build_outbounds(link, outbound_mark=outbound_mark),
     }
+    routing = build_routing_config(routing_profile)
+    if routing is not None:
+        config["routing"] = routing
+    return config
 
 
 class XrayProcess:

--- a/gui/xrayebator_gui/helper/__init__.py
+++ b/gui/xrayebator_gui/helper/__init__.py
@@ -1,0 +1,1 @@
+"""Privileged, deliberately narrow TUN service."""

--- a/gui/xrayebator_gui/helper/linux_network.py
+++ b/gui/xrayebator_gui/helper/linux_network.py
@@ -1,4 +1,4 @@
-"""Linux-only DNS and nftables guard operations for the privileged helper."""
+"""Linux nftables guard and DNS redirection for the privileged helper."""
 
 from __future__ import annotations
 
@@ -22,11 +22,7 @@ class LinuxNetwork:
         self.command_timeout = command_timeout
 
     def check_dependencies(self) -> None:
-        missing = [
-            command
-            for command in ("nft", "resolvectl")
-            if shutil.which(command) is None
-        ]
+        missing = [command for command in ("nft",) if shutil.which(command) is None]
         if missing:
             raise NetworkError(
                 "Не установлены зависимости TUN helper: " + ", ".join(missing)
@@ -78,16 +74,13 @@ class LinuxNetwork:
         interface: str,
         servers: tuple[str, ...] = ("1.1.1.1", "8.8.8.8"),
     ) -> None:
+        """Wait for TUN; DNS redirection itself is in the nft transaction."""
+        del servers
         self.wait_for_interface(interface)
-        self._run(["resolvectl", "dns", interface, *servers])
-        self._run(["resolvectl", "domain", interface, "~."])
-        self._run(["resolvectl", "default-route", interface, "yes"])
 
     def restore_dns(self, interface: str) -> None:
-        self._run(
-            ["resolvectl", "revert", interface],
-            check=False,
-        )
+        # Removing the nft table restores the original resolver unchanged.
+        del interface
 
     def _run(
         self,
@@ -122,6 +115,15 @@ def build_nft_rules(interface: str, mark: int) -> str:
         raise NetworkError(f"Некорректная firewall mark: {mark}")
     return (
         f"table inet {NFT_TABLE} {{\n"
+        "  chain dns_output {\n"
+        "    type nat hook output priority -100; policy accept;\n"
+        "    meta nfproto ipv4 udp dport 53 dnat ip to 1.1.1.1\n"
+        "    meta nfproto ipv4 tcp dport 53 dnat ip to 1.1.1.1\n"
+        "    meta nfproto ipv6 udp dport 53 dnat ip6 to "
+        "2606:4700:4700::1111\n"
+        "    meta nfproto ipv6 tcp dport 53 dnat ip6 to "
+        "2606:4700:4700::1111\n"
+        "  }\n"
         "  chain output {\n"
         "    type filter hook output priority -50; policy accept;\n"
         '    oifname "lo" accept\n'

--- a/gui/xrayebator_gui/helper/linux_network.py
+++ b/gui/xrayebator_gui/helper/linux_network.py
@@ -49,6 +49,11 @@ class LinuxNetwork:
         script = build_nft_rules(interface, mark)
         self._run(["nft", "-f", "-"], input_text=script)
 
+    def validate_guard(self, interface: str, mark: int) -> None:
+        """Ask nftables to parse/check the transaction without applying it."""
+        script = build_nft_rules(interface, mark)
+        self._run(["nft", "--check", "-f", "-"], input_text=script)
+
     def disable_guard(self) -> None:
         if not self.guard_exists():
             return

--- a/gui/xrayebator_gui/helper/linux_network.py
+++ b/gui/xrayebator_gui/helper/linux_network.py
@@ -1,0 +1,135 @@
+"""Linux-only DNS and nftables guard operations for the privileged helper."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import socket
+import subprocess
+import time
+from typing import Optional
+
+NFT_TABLE = "xrayebator_gui"
+INTERFACE_RE = re.compile(r"^[A-Za-z0-9_.-]{1,15}$")
+
+
+class NetworkError(RuntimeError):
+    """A privileged network operation failed."""
+
+
+class LinuxNetwork:
+    def __init__(self, *, command_timeout: float = 15.0):
+        self.command_timeout = command_timeout
+
+    def check_dependencies(self) -> None:
+        missing = [
+            command
+            for command in ("nft", "resolvectl")
+            if shutil.which(command) is None
+        ]
+        if missing:
+            raise NetworkError(
+                "Не установлены зависимости TUN helper: " + ", ".join(missing)
+            )
+
+    def guard_exists(self) -> bool:
+        if shutil.which("nft") is None:
+            return False
+        result = self._run(
+            ["nft", "list", "table", "inet", NFT_TABLE],
+            check=False,
+        )
+        return result.returncode == 0
+
+    def enable_guard(self, interface: str, mark: int) -> None:
+        if not INTERFACE_RE.fullmatch(interface):
+            raise NetworkError(f"Некорректное имя TUN-интерфейса: {interface!r}")
+        if not 1 <= mark <= 0xFFFFFFFF:
+            raise NetworkError(f"Некорректная firewall mark: {mark}")
+        if self.guard_exists():
+            # The table name is private to this helper and its rules are fixed.
+            # Keeping it in place avoids a leak window during recovery/switching.
+            return
+        script = build_nft_rules(interface, mark)
+        self._run(["nft", "-f", "-"], input_text=script)
+
+    def disable_guard(self) -> None:
+        if not self.guard_exists():
+            return
+        self._run(["nft", "delete", "table", "inet", NFT_TABLE])
+
+    def wait_for_interface(
+        self,
+        interface: str,
+        *,
+        timeout: float = 8.0,
+    ) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                socket.if_nametoindex(interface)
+                return
+            except OSError:
+                time.sleep(0.1)
+        raise NetworkError(f"TUN-интерфейс {interface} не появился")
+
+    def configure_dns(
+        self,
+        interface: str,
+        servers: tuple[str, ...] = ("1.1.1.1", "8.8.8.8"),
+    ) -> None:
+        self.wait_for_interface(interface)
+        self._run(["resolvectl", "dns", interface, *servers])
+        self._run(["resolvectl", "domain", interface, "~."])
+        self._run(["resolvectl", "default-route", interface, "yes"])
+
+    def restore_dns(self, interface: str) -> None:
+        self._run(
+            ["resolvectl", "revert", interface],
+            check=False,
+        )
+
+    def _run(
+        self,
+        args: list[str],
+        *,
+        input_text: Optional[str] = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
+        try:
+            result = subprocess.run(
+                args,
+                input=input_text,
+                capture_output=True,
+                text=True,
+                timeout=self.command_timeout,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise NetworkError(f"Не удалось выполнить {args[0]}: {exc}") from exc
+        if check and result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise NetworkError(
+                f"{' '.join(args)} завершился с {result.returncode}: {detail}"
+            )
+        return result
+
+
+def build_nft_rules(interface: str, mark: int) -> str:
+    if not INTERFACE_RE.fullmatch(interface):
+        raise NetworkError(f"Некорректное имя TUN-интерфейса: {interface!r}")
+    if not 1 <= mark <= 0xFFFFFFFF:
+        raise NetworkError(f"Некорректная firewall mark: {mark}")
+    return (
+        f"table inet {NFT_TABLE} {{\n"
+        "  chain output {\n"
+        "    type filter hook output priority -50; policy accept;\n"
+        '    oifname "lo" accept\n'
+        f'    oifname "{interface}" accept\n'
+        f"    meta mark {mark} accept\n"
+        "    udp sport 68 udp dport 67 accept\n"
+        "    udp sport 546 udp dport 547 accept\n"
+        "    reject\n"
+        "  }\n"
+        "}\n"
+    )

--- a/gui/xrayebator_gui/helper/runtime.py
+++ b/gui/xrayebator_gui/helper/runtime.py
@@ -1,0 +1,282 @@
+"""Stateful owner of Xray TUN, DNS and the Linux kill-switch guard."""
+
+from __future__ import annotations
+
+import os
+import socket
+import stat
+from dataclasses import replace
+from pathlib import Path
+from typing import Callable, Optional
+
+from ..core.subscription import VlessLink
+from ..core.xray import (
+    XRAY_TUN_VERSION,
+    XrayProcess,
+    _installed_version,
+    build_tun_client_config,
+)
+from .linux_network import LinuxNetwork
+from .state import RouteStateStore
+
+CORE_BINARY = Path("/usr/lib/xrayebator-gui/xray")
+RUNTIME_DIR = Path("/run/xrayebator-gui")
+TUN_INTERFACE = "xrayebator0"
+OUTBOUND_MARK = 0x5852
+
+
+class TunRuntimeError(RuntimeError):
+    """Privileged TUN runtime operation failed."""
+
+
+ProcessFactory = Callable[[Path, Path, Path], XrayProcess]
+Resolver = Callable[[str, int], str]
+BinaryValidator = Callable[[Path], None]
+
+
+class TunRuntime:
+    def __init__(
+        self,
+        *,
+        core_binary: Path = CORE_BINARY,
+        runtime_dir: Path = RUNTIME_DIR,
+        network: Optional[LinuxNetwork] = None,
+        process_factory: Optional[ProcessFactory] = None,
+        resolver: Optional[Resolver] = None,
+        binary_validator: Optional[BinaryValidator] = None,
+        state_store: Optional[RouteStateStore] = None,
+    ):
+        self.core_binary = Path(core_binary)
+        self.runtime_dir = Path(runtime_dir)
+        self.network = network or LinuxNetwork()
+        self._process_factory = process_factory or _make_process
+        self._resolver = resolver or resolve_server
+        self._binary_validator = binary_validator or validate_core_binary
+        self._state_store = state_store or RouteStateStore()
+        self._process: Optional[XrayProcess] = None
+        self._state = "guarded_error" if self.network.guard_exists() else "disconnected"
+        self._error: Optional[str] = (
+            "Обнаружен kill switch от предыдущего аварийного завершения"
+            if self._state == "guarded_error"
+            else None
+        )
+        self._external_ip: Optional[str] = None
+        self._resolved_routes: dict[str, VlessLink] = {}
+
+    def recover(self) -> dict:
+        """Restore the last verified route while preserving a stale guard."""
+        if self._state != "guarded_error":
+            return self._result()
+        try:
+            stored = self._state_store.load()
+            if stored is None:
+                return self._result()
+            self.network.check_dependencies()
+            self._binary_validator(self.core_binary)
+            resolved = replace(
+                stored.route,
+                address=stored.resolved_address,
+            )
+            self._resolved_routes[stored.route.raw] = resolved
+            self.network.enable_guard(TUN_INTERFACE, OUTBOUND_MARK)
+            self._start_process(resolved)
+            self.network.configure_dns(TUN_INTERFACE)
+        except Exception as exc:
+            self._stop_process()
+            self._state = "guarded_error"
+            self._error = f"Автовосстановление TUN не удалось: {exc}"
+            return self._result()
+        self._state = "connected"
+        self._error = None
+        return self._result()
+
+    def status(self) -> dict:
+        if self._state == "connected" and (
+            self._process is None or not self._process.is_running()
+        ):
+            self._state = "guarded_error"
+            self._error = "Xray остановился; kill switch оставлен закрытым"
+            self._external_ip = None
+        return self._result()
+
+    def connect(self, route: VlessLink) -> dict:
+        if self._state == "connected":
+            raise TunRuntimeError("TUN уже подключён")
+        if self._state not in {"disconnected", "guarded_error"}:
+            raise TunRuntimeError(f"Нельзя подключиться из состояния {self._state}")
+        self._state = "connecting"
+        self._error = None
+        self._external_ip = None
+        try:
+            self.network.check_dependencies()
+            self._binary_validator(self.core_binary)
+            resolved = self._resolve(route)
+            self.network.enable_guard(TUN_INTERFACE, OUTBOUND_MARK)
+            self._start_process(resolved)
+            self.network.configure_dns(TUN_INTERFACE)
+            self._state_store.save(route, resolved.address)
+        except Exception as exc:
+            self._cleanup(remove_guard=True)
+            self._state = "disconnected"
+            self._error = str(exc)
+            raise TunRuntimeError(str(exc)) from exc
+        self._state = "connected"
+        return self._result()
+
+    def switch(self, route: VlessLink) -> dict:
+        if self._state not in {"connected", "guarded_error"}:
+            raise TunRuntimeError("Маршрут можно менять только при активном TUN")
+        self._state = "switching"
+        self._error = None
+        self._external_ip = None
+        try:
+            resolved = self._resolve(route)
+            self.network.restore_dns(TUN_INTERFACE)
+            self._stop_process()
+            self._start_process(resolved)
+            self.network.configure_dns(TUN_INTERFACE)
+            self._state_store.save(route, resolved.address)
+        except Exception as exc:
+            self._stop_process()
+            self._state = "guarded_error"
+            self._error = str(exc)
+            raise TunRuntimeError(
+                f"Новый маршрут не запущен; kill switch закрыт: {exc}"
+            ) from exc
+        self._state = "connected"
+        return self._result()
+
+    def verify(self) -> dict:
+        status = self.status()
+        if status["state"] != "connected" or self._process is None:
+            raise TunRuntimeError(self._error or "Нельзя проверить неактивный TUN")
+        external_ip = self._process.health_check_tun()
+        if not external_ip:
+            raise TunRuntimeError("TUN не прошёл проверку внешнего IP")
+        self._external_ip = external_ip
+        return self._result()
+
+    def disconnect(self) -> dict:
+        self._state = "disconnecting"
+        errors = self._cleanup(remove_guard=True)
+        self._state = "disconnected"
+        self._external_ip = None
+        self._error = "; ".join(errors) if errors else None
+        try:
+            self._state_store.remove()
+        except Exception as exc:
+            errors.append(f"persisted state: {exc}")
+            self._error = "; ".join(errors)
+        if errors:
+            raise TunRuntimeError(self._error)
+        return self._result()
+
+    def _resolve(self, route: VlessLink) -> VlessLink:
+        cached = self._resolved_routes.get(route.raw)
+        if cached is not None:
+            return cached
+        address = self._resolver(route.address, route.port)
+        resolved = replace(route, address=address)
+        self._resolved_routes[route.raw] = resolved
+        if len(self._resolved_routes) > 16:
+            oldest = next(iter(self._resolved_routes))
+            del self._resolved_routes[oldest]
+        return resolved
+
+    def _start_process(self, route: VlessLink) -> None:
+        self.runtime_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.runtime_dir, 0o750)
+        process = self._process_factory(
+            self.core_binary,
+            self.runtime_dir / "config.json",
+            self.runtime_dir / "xray.log",
+        )
+        config = build_tun_client_config(
+            route,
+            system="Linux",
+            interface_name=TUN_INTERFACE,
+            outbound_mark=OUTBOUND_MARK,
+        )
+        process.start(config)
+        self._process = process
+
+    def _stop_process(self) -> None:
+        if self._process is None:
+            return
+        try:
+            self._process.stop()
+        finally:
+            self._process = None
+
+    def _cleanup(self, *, remove_guard: bool) -> list[str]:
+        errors: list[str] = []
+        try:
+            self.network.restore_dns(TUN_INTERFACE)
+        except Exception as exc:
+            errors.append(f"DNS: {exc}")
+        try:
+            self._stop_process()
+        except Exception as exc:
+            errors.append(f"Xray: {exc}")
+        if remove_guard:
+            try:
+                self.network.disable_guard()
+            except Exception as exc:
+                errors.append(f"kill switch: {exc}")
+        return errors
+
+    def _result(self) -> dict:
+        return {
+            "state": self._state,
+            "external_ip": self._external_ip,
+            "error": self._error,
+        }
+
+
+def _make_process(
+    binary: Path,
+    config_path: Path,
+    stderr_path: Path,
+) -> XrayProcess:
+    return XrayProcess(
+        binary,
+        config_path=config_path,
+        stderr_path=stderr_path,
+    )
+
+
+def validate_core_binary(path: Path) -> None:
+    try:
+        info = path.stat()
+    except OSError as exc:
+        raise TunRuntimeError(f"Xray core не установлен: {path}") from exc
+    if not stat.S_ISREG(info.st_mode):
+        raise TunRuntimeError(f"Xray core не является обычным файлом: {path}")
+    if info.st_uid != 0 or info.st_mode & 0o022:
+        raise TunRuntimeError(
+            "Xray core должен принадлежать root и не быть доступен для записи "
+            f"group/other: {path}"
+        )
+    if not info.st_mode & stat.S_IXUSR:
+        raise TunRuntimeError(f"Xray core не исполняемый: {path}")
+    version = _installed_version(path)
+    if version != XRAY_TUN_VERSION:
+        raise TunRuntimeError(
+            f"Установлен Xray {version or '?'}, требуется {XRAY_TUN_VERSION}"
+        )
+
+
+def resolve_server(host: str, port: int) -> str:
+    try:
+        records = socket.getaddrinfo(
+            host,
+            port,
+            type=socket.SOCK_STREAM,
+        )
+    except socket.gaierror as exc:
+        raise TunRuntimeError(f"Не удалось разрешить адрес VPS {host}: {exc}") from exc
+    if not records:
+        raise TunRuntimeError(f"DNS не вернул адрес VPS {host}")
+    # Prefer IPv4 for the first desktop slice; IPv6 remains a valid fallback.
+    records.sort(key=lambda item: item[0] != socket.AF_INET)
+    return records[0][4][0]

--- a/gui/xrayebator_gui/helper/runtime.py
+++ b/gui/xrayebator_gui/helper/runtime.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from ..core.subscription import VlessLink
+from ..core.routing import RoutingProfile
 from ..core.xray import (
     XRAY_TUN_VERSION,
     XrayProcess,
@@ -62,6 +63,8 @@ class TunRuntime:
         )
         self._external_ip: Optional[str] = None
         self._resolved_routes: dict[str, VlessLink] = {}
+        self._active_route_raw: Optional[str] = None
+        self._active_profile: Optional[RoutingProfile] = None
 
     def recover(self) -> dict:
         """Restore the last verified route while preserving a stale guard."""
@@ -79,7 +82,7 @@ class TunRuntime:
             )
             self._resolved_routes[stored.route.raw] = resolved
             self.network.enable_guard(TUN_INTERFACE, OUTBOUND_MARK)
-            self._start_process(resolved)
+            self._start_process(resolved, stored.routing_profile)
             self.network.configure_dns(TUN_INTERFACE)
         except Exception as exc:
             self._stop_process()
@@ -88,6 +91,8 @@ class TunRuntime:
             return self._result()
         self._state = "connected"
         self._error = None
+        self._active_route_raw = stored.route.raw
+        self._active_profile = stored.routing_profile
         return self._result()
 
     def status(self) -> dict:
@@ -99,9 +104,18 @@ class TunRuntime:
             self._external_ip = None
         return self._result()
 
-    def connect(self, route: VlessLink) -> dict:
+    def connect(
+        self,
+        route: VlessLink,
+        routing_profile: RoutingProfile,
+    ) -> dict:
         if self._state == "connected":
-            raise TunRuntimeError("TUN уже подключён")
+            if (
+                route.raw == self._active_route_raw
+                and routing_profile == self._active_profile
+            ):
+                return self._result()
+            return self.switch(route, routing_profile)
         if self._state not in {"disconnected", "guarded_error"}:
             raise TunRuntimeError(f"Нельзя подключиться из состояния {self._state}")
         self._state = "connecting"
@@ -112,18 +126,24 @@ class TunRuntime:
             self._binary_validator(self.core_binary)
             resolved = self._resolve(route)
             self.network.enable_guard(TUN_INTERFACE, OUTBOUND_MARK)
-            self._start_process(resolved)
+            self._start_process(resolved, routing_profile)
             self.network.configure_dns(TUN_INTERFACE)
-            self._state_store.save(route, resolved.address)
+            self._state_store.save(route, resolved.address, routing_profile)
         except Exception as exc:
             self._cleanup(remove_guard=True)
             self._state = "disconnected"
             self._error = str(exc)
             raise TunRuntimeError(str(exc)) from exc
         self._state = "connected"
+        self._active_route_raw = route.raw
+        self._active_profile = routing_profile
         return self._result()
 
-    def switch(self, route: VlessLink) -> dict:
+    def switch(
+        self,
+        route: VlessLink,
+        routing_profile: RoutingProfile,
+    ) -> dict:
         if self._state not in {"connected", "guarded_error"}:
             raise TunRuntimeError("Маршрут можно менять только при активном TUN")
         self._state = "switching"
@@ -133,9 +153,9 @@ class TunRuntime:
             resolved = self._resolve(route)
             self.network.restore_dns(TUN_INTERFACE)
             self._stop_process()
-            self._start_process(resolved)
+            self._start_process(resolved, routing_profile)
             self.network.configure_dns(TUN_INTERFACE)
-            self._state_store.save(route, resolved.address)
+            self._state_store.save(route, resolved.address, routing_profile)
         except Exception as exc:
             self._stop_process()
             self._state = "guarded_error"
@@ -144,6 +164,8 @@ class TunRuntime:
                 f"Новый маршрут не запущен; kill switch закрыт: {exc}"
             ) from exc
         self._state = "connected"
+        self._active_route_raw = route.raw
+        self._active_profile = routing_profile
         return self._result()
 
     def verify(self) -> dict:
@@ -161,6 +183,8 @@ class TunRuntime:
         errors = self._cleanup(remove_guard=True)
         self._state = "disconnected"
         self._external_ip = None
+        self._active_route_raw = None
+        self._active_profile = None
         self._error = "; ".join(errors) if errors else None
         try:
             self._state_store.remove()
@@ -183,7 +207,11 @@ class TunRuntime:
             del self._resolved_routes[oldest]
         return resolved
 
-    def _start_process(self, route: VlessLink) -> None:
+    def _start_process(
+        self,
+        route: VlessLink,
+        routing_profile: RoutingProfile,
+    ) -> None:
         self.runtime_dir.mkdir(parents=True, exist_ok=True)
         os.chmod(self.runtime_dir, 0o750)
         process = self._process_factory(
@@ -196,6 +224,7 @@ class TunRuntime:
             system="Linux",
             interface_name=TUN_INTERFACE,
             outbound_mark=OUTBOUND_MARK,
+            routing_profile=routing_profile,
         )
         process.start(config)
         self._process = process
@@ -264,6 +293,23 @@ def validate_core_binary(path: Path) -> None:
         raise TunRuntimeError(
             f"Установлен Xray {version or '?'}, требуется {XRAY_TUN_VERSION}"
         )
+    for resource in ("geoip.dat", "geosite.dat"):
+        resource_path = path.parent / resource
+        try:
+            resource_info = resource_path.stat()
+        except OSError as exc:
+            raise TunRuntimeError(
+                f"Не установлен routing resource: {resource_path}"
+            ) from exc
+        if (
+            not stat.S_ISREG(resource_info.st_mode)
+            or resource_info.st_uid != 0
+            or resource_info.st_mode & 0o022
+        ):
+            raise TunRuntimeError(
+                "Routing resource должен принадлежать root и не быть "
+                f"доступен для записи group/other: {resource_path}"
+            )
 
 
 def resolve_server(host: str, port: int) -> str:

--- a/gui/xrayebator_gui/helper/runtime.py
+++ b/gui/xrayebator_gui/helper/runtime.py
@@ -104,6 +104,12 @@ class TunRuntime:
             self._external_ip = None
         return self._result()
 
+    def selftest(self) -> dict:
+        self.network.check_dependencies()
+        self._binary_validator(self.core_binary)
+        self.network.validate_guard(TUN_INTERFACE, OUTBOUND_MARK)
+        return self._result()
+
     def connect(
         self,
         route: VlessLink,

--- a/gui/xrayebator_gui/helper/service.py
+++ b/gui/xrayebator_gui/helper/service.py
@@ -55,10 +55,12 @@ class HelperServer:
         *,
         socket_path: Path = DEFAULT_SOCKET,
         allowed_gid: int,
+        allowed_uid: Optional[int] = None,
     ):
         self.application = application
         self.socket_path = Path(socket_path)
         self.allowed_gid = allowed_gid
+        self.allowed_uid = allowed_uid
         self._server: Optional[socket.socket] = None
         self._stopping = False
 
@@ -102,7 +104,12 @@ class HelperServer:
         request_id = ""
         try:
             uid, gid = peer_credentials(connection)
-            if not authorized_peer(uid, gid, self.allowed_gid):
+            if not authorized_peer(
+                uid,
+                gid,
+                self.allowed_gid,
+                allowed_uid=self.allowed_uid,
+            ):
                 raise ServiceError(f"UID {uid} не авторизован для TUN helper")
             wire = read_request(connection)
             request_id = request_id_from_wire(wire)
@@ -138,9 +145,17 @@ def peer_credentials(connection: socket.socket) -> tuple[int, int]:
     return uid, gid
 
 
-def authorized_peer(uid: int, primary_gid: int, allowed_gid: int) -> bool:
+def authorized_peer(
+    uid: int,
+    primary_gid: int,
+    allowed_gid: int,
+    *,
+    allowed_uid: Optional[int] = None,
+) -> bool:
     if uid == 0:
         return True
+    if allowed_uid is not None:
+        return uid == allowed_uid
     try:
         username = pwd.getpwuid(uid).pw_name
         groups = os.getgrouplist(username, primary_gid)
@@ -169,16 +184,23 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Privileged Xrayebator TUN helper")
     parser.add_argument("--socket", type=Path, default=DEFAULT_SOCKET)
     parser.add_argument("--group", default=DEFAULT_GROUP)
+    parser.add_argument("--socket-gid", type=int)
+    parser.add_argument("--allow-uid", type=int)
     parser.add_argument("--core", type=Path, default=CORE_BINARY)
     args = parser.parse_args()
 
     if os.geteuid() != 0:
         parser.error("helper должен запускаться от root")
-    try:
-        allowed_gid = grp.getgrnam(args.group).gr_gid
-    except KeyError as exc:
-        parser.error(f"группа {args.group!r} не существует")
-        raise AssertionError from exc
+    if args.socket_gid is not None:
+        if args.socket_gid < 0:
+            parser.error("--socket-gid должен быть неотрицательным")
+        allowed_gid = args.socket_gid
+    else:
+        try:
+            allowed_gid = grp.getgrnam(args.group).gr_gid
+        except KeyError as exc:
+            parser.error(f"группа {args.group!r} не существует")
+            raise AssertionError from exc
 
     runtime = TunRuntime(
         core_binary=args.core,
@@ -189,6 +211,7 @@ def main() -> int:
         HelperApplication(runtime),
         socket_path=args.socket,
         allowed_gid=allowed_gid,
+        allowed_uid=args.allow_uid,
     )
     signal.signal(signal.SIGTERM, server.stop)
     signal.signal(signal.SIGINT, server.stop)

--- a/gui/xrayebator_gui/helper/service.py
+++ b/gui/xrayebator_gui/helper/service.py
@@ -1,0 +1,206 @@
+"""Unix-socket service exposing the narrow privileged TUN API."""
+
+from __future__ import annotations
+
+import argparse
+import grp
+import os
+import pwd
+import signal
+import socket
+import struct
+from pathlib import Path
+from typing import Optional
+
+from ..core.helper_protocol import (
+    MAX_MESSAGE_BYTES,
+    HelperRequest,
+    ProtocolError,
+    decode_request,
+    encode_response,
+    request_id_from_wire,
+)
+from .runtime import CORE_BINARY, RUNTIME_DIR, TunRuntime
+
+DEFAULT_GROUP = "xrayebator"
+DEFAULT_SOCKET = RUNTIME_DIR / "helper.sock"
+
+
+class ServiceError(RuntimeError):
+    """Privileged helper service setup or authorization failed."""
+
+
+class HelperApplication:
+    def __init__(self, runtime: TunRuntime):
+        self.runtime = runtime
+
+    def handle(self, request: HelperRequest) -> dict:
+        if request.action == "status":
+            return self.runtime.status()
+        if request.action == "connect" and request.route is not None:
+            return self.runtime.connect(request.route)
+        if request.action == "switch" and request.route is not None:
+            return self.runtime.switch(request.route)
+        if request.action == "verify":
+            return self.runtime.verify()
+        if request.action == "disconnect":
+            return self.runtime.disconnect()
+        raise ProtocolError(f"Команда {request.action} не поддерживается")
+
+
+class HelperServer:
+    def __init__(
+        self,
+        application: HelperApplication,
+        *,
+        socket_path: Path = DEFAULT_SOCKET,
+        allowed_gid: int,
+    ):
+        self.application = application
+        self.socket_path = Path(socket_path)
+        self.allowed_gid = allowed_gid
+        self._server: Optional[socket.socket] = None
+        self._stopping = False
+
+    def serve_forever(self) -> None:
+        self._prepare_socket()
+        assert self._server is not None
+        try:
+            while not self._stopping:
+                try:
+                    connection, _ = self._server.accept()
+                except socket.timeout:
+                    continue
+                with connection:
+                    self._handle_connection(connection)
+        finally:
+            self.close()
+
+    def stop(self, *_args) -> None:
+        self._stopping = True
+
+    def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            self._server = None
+        self.socket_path.unlink(missing_ok=True)
+
+    def _prepare_socket(self) -> None:
+        self.socket_path.parent.mkdir(parents=True, exist_ok=True)
+        os.chown(self.socket_path.parent, 0, self.allowed_gid)
+        os.chmod(self.socket_path.parent, 0o750)
+        self.socket_path.unlink(missing_ok=True)
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(str(self.socket_path))
+        os.chown(self.socket_path, 0, self.allowed_gid)
+        os.chmod(self.socket_path, 0o660)
+        server.listen(8)
+        server.settimeout(1.0)
+        self._server = server
+
+    def _handle_connection(self, connection: socket.socket) -> None:
+        request_id = ""
+        try:
+            uid, gid = peer_credentials(connection)
+            if not authorized_peer(uid, gid, self.allowed_gid):
+                raise ServiceError(f"UID {uid} не авторизован для TUN helper")
+            wire = read_request(connection)
+            request_id = request_id_from_wire(wire)
+            request = decode_request(wire)
+            request_id = request.request_id
+            result = self.application.handle(request)
+            response = encode_response(
+                request_id,
+                ok=True,
+                state=result["state"],
+                external_ip=result.get("external_ip"),
+                error=result.get("error"),
+            )
+        except Exception as exc:
+            response = encode_response(
+                request_id,
+                ok=False,
+                state=self.application.runtime.status()["state"],
+                error=str(exc),
+            )
+        connection.sendall(response)
+
+
+def peer_credentials(connection: socket.socket) -> tuple[int, int]:
+    if not hasattr(socket, "SO_PEERCRED"):
+        raise ServiceError("SO_PEERCRED недоступен на этой платформе")
+    raw = connection.getsockopt(
+        socket.SOL_SOCKET,
+        socket.SO_PEERCRED,
+        struct.calcsize("3i"),
+    )
+    _pid, uid, gid = struct.unpack("3i", raw)
+    return uid, gid
+
+
+def authorized_peer(uid: int, primary_gid: int, allowed_gid: int) -> bool:
+    if uid == 0:
+        return True
+    try:
+        username = pwd.getpwuid(uid).pw_name
+        groups = os.getgrouplist(username, primary_gid)
+    except (KeyError, OSError):
+        return False
+    return allowed_gid in groups
+
+
+def read_request(connection: socket.socket) -> bytes:
+    data = bytearray()
+    while True:
+        chunk = connection.recv(min(65536, MAX_MESSAGE_BYTES + 1 - len(data)))
+        if not chunk:
+            raise ProtocolError("Клиент закрыл соединение до конца запроса")
+        data.extend(chunk)
+        if len(data) > MAX_MESSAGE_BYTES:
+            raise ProtocolError("Запрос helper слишком велик")
+        newline = data.find(b"\n")
+        if newline >= 0:
+            if data[newline + 1 :]:
+                raise ProtocolError("За одно соединение разрешён один запрос")
+            return bytes(data[:newline])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Privileged Xrayebator TUN helper")
+    parser.add_argument("--socket", type=Path, default=DEFAULT_SOCKET)
+    parser.add_argument("--group", default=DEFAULT_GROUP)
+    parser.add_argument("--core", type=Path, default=CORE_BINARY)
+    args = parser.parse_args()
+
+    if os.geteuid() != 0:
+        parser.error("helper должен запускаться от root")
+    try:
+        allowed_gid = grp.getgrnam(args.group).gr_gid
+    except KeyError as exc:
+        parser.error(f"группа {args.group!r} не существует")
+        raise AssertionError from exc
+
+    runtime = TunRuntime(
+        core_binary=args.core,
+        runtime_dir=args.socket.parent,
+    )
+    runtime.recover()
+    server = HelperServer(
+        HelperApplication(runtime),
+        socket_path=args.socket,
+        allowed_gid=allowed_gid,
+    )
+    signal.signal(signal.SIGTERM, server.stop)
+    signal.signal(signal.SIGINT, server.stop)
+    try:
+        server.serve_forever()
+    finally:
+        try:
+            runtime.disconnect()
+        except Exception:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gui/xrayebator_gui/helper/service.py
+++ b/gui/xrayebator_gui/helper/service.py
@@ -37,10 +37,24 @@ class HelperApplication:
     def handle(self, request: HelperRequest) -> dict:
         if request.action == "status":
             return self.runtime.status()
-        if request.action == "connect" and request.route is not None:
-            return self.runtime.connect(request.route)
-        if request.action == "switch" and request.route is not None:
-            return self.runtime.switch(request.route)
+        if (
+            request.action == "connect"
+            and request.route is not None
+            and request.routing_profile is not None
+        ):
+            return self.runtime.connect(
+                request.route,
+                request.routing_profile,
+            )
+        if (
+            request.action == "switch"
+            and request.route is not None
+            and request.routing_profile is not None
+        ):
+            return self.runtime.switch(
+                request.route,
+                request.routing_profile,
+            )
         if request.action == "verify":
             return self.runtime.verify()
         if request.action == "disconnect":

--- a/gui/xrayebator_gui/helper/service.py
+++ b/gui/xrayebator_gui/helper/service.py
@@ -37,6 +37,8 @@ class HelperApplication:
     def handle(self, request: HelperRequest) -> dict:
         if request.action == "status":
             return self.runtime.status()
+        if request.action == "selftest":
+            return self.runtime.selftest()
         if (
             request.action == "connect"
             and request.route is not None

--- a/gui/xrayebator_gui/helper/state.py
+++ b/gui/xrayebator_gui/helper/state.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
+from ..core.routing import RoutingProfile
 from ..core.subscription import VlessLink, parse_link
 
 DEFAULT_STATE_PATH = Path("/var/lib/xrayebator-gui/last-route.json")
@@ -24,6 +25,7 @@ class StateError(RuntimeError):
 class StoredRoute:
     route: VlessLink
     resolved_address: str
+    routing_profile: RoutingProfile = RoutingProfile.FULL
 
 
 class RouteStateStore:
@@ -36,7 +38,12 @@ class RouteStateStore:
         self.path = Path(path)
         self.expected_uid = expected_uid
 
-    def save(self, route: VlessLink, resolved_address: str) -> None:
+    def save(
+        self,
+        route: VlessLink,
+        resolved_address: str,
+        routing_profile: RoutingProfile,
+    ) -> None:
         try:
             ipaddress.ip_address(resolved_address)
         except ValueError as exc:
@@ -55,9 +62,10 @@ class RouteStateStore:
                 fd = -1
                 json.dump(
                     {
-                        "version": 1,
+                        "version": 2,
                         "route": route.raw,
                         "resolved_address": resolved_address,
+                        "routing_profile": routing_profile.value,
                     },
                     stream,
                     separators=(",", ":"),
@@ -88,9 +96,10 @@ class RouteStateStore:
             "version",
             "route",
             "resolved_address",
+            "routing_profile",
         }:
             raise StateError("Persisted state имеет неизвестную схему")
-        if payload["version"] != 1:
+        if payload["version"] != 2:
             raise StateError("Версия persisted state не поддерживается")
         if not isinstance(payload["route"], str):
             raise StateError("Persisted VLESS route должен быть строкой")
@@ -101,7 +110,15 @@ class RouteStateStore:
             address = str(ipaddress.ip_address(payload["resolved_address"]))
         except (ValueError, TypeError) as exc:
             raise StateError("Persisted resolved address некорректен") from exc
-        return StoredRoute(route=route, resolved_address=address)
+        try:
+            routing_profile = RoutingProfile(payload["routing_profile"])
+        except (TypeError, ValueError) as exc:
+            raise StateError("Persisted routing profile некорректен") from exc
+        return StoredRoute(
+            route=route,
+            resolved_address=address,
+            routing_profile=routing_profile,
+        )
 
     def remove(self) -> None:
         self.path.unlink(missing_ok=True)

--- a/gui/xrayebator_gui/helper/state.py
+++ b/gui/xrayebator_gui/helper/state.py
@@ -1,0 +1,107 @@
+"""Root-only last-known-good route state for fail-closed recovery."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..core.subscription import VlessLink, parse_link
+
+DEFAULT_STATE_PATH = Path("/var/lib/xrayebator-gui/last-route.json")
+
+
+class StateError(RuntimeError):
+    """Persisted helper state is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class StoredRoute:
+    route: VlessLink
+    resolved_address: str
+
+
+class RouteStateStore:
+    def __init__(
+        self,
+        path: Path = DEFAULT_STATE_PATH,
+        *,
+        expected_uid: int = 0,
+    ):
+        self.path = Path(path)
+        self.expected_uid = expected_uid
+
+    def save(self, route: VlessLink, resolved_address: str) -> None:
+        try:
+            ipaddress.ip_address(resolved_address)
+        except ValueError as exc:
+            raise StateError(
+                f"Нельзя сохранить не-IP адрес маршрута: {resolved_address}"
+            ) from exc
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.path.parent, 0o700)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            dir=self.path.parent,
+        )
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                fd = -1
+                json.dump(
+                    {
+                        "version": 1,
+                        "route": route.raw,
+                        "resolved_address": resolved_address,
+                    },
+                    stream,
+                    separators=(",", ":"),
+                )
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(tmp_name, self.path)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            Path(tmp_name).unlink(missing_ok=True)
+
+    def load(self) -> Optional[StoredRoute]:
+        if not self.path.exists():
+            return None
+        info = self.path.lstat()
+        if (
+            not stat.S_ISREG(info.st_mode)
+            or info.st_uid != self.expected_uid
+            or info.st_mode & 0o077
+        ):
+            raise StateError(f"Небезопасные owner/mode persisted state: {self.path}")
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise StateError("Persisted state повреждён") from exc
+        if not isinstance(payload, dict) or set(payload) != {
+            "version",
+            "route",
+            "resolved_address",
+        }:
+            raise StateError("Persisted state имеет неизвестную схему")
+        if payload["version"] != 1:
+            raise StateError("Версия persisted state не поддерживается")
+        if not isinstance(payload["route"], str):
+            raise StateError("Persisted VLESS route должен быть строкой")
+        route = parse_link(payload["route"])
+        if route is None:
+            raise StateError("Persisted VLESS route некорректен")
+        try:
+            address = str(ipaddress.ip_address(payload["resolved_address"]))
+        except (ValueError, TypeError) as exc:
+            raise StateError("Persisted resolved address некорректен") from exc
+        return StoredRoute(route=route, resolved_address=address)
+
+    def remove(self) -> None:
+        self.path.unlink(missing_ok=True)

--- a/gui/xrayebator_gui/resources/linux/install-helper.sh
+++ b/gui/xrayebator_gui/resources/linux/install-helper.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+XRAY_VERSION="v26.7.28"
+INSTALL_ROOT="/opt/xrayebator-gui"
+CONFIG_ROOT="/etc/xrayebator-gui"
+SERVICE_PATH="/etc/systemd/system/xrayebator-gui-helper.service"
+
+die() {
+  echo "xrayebator helper: $*" >&2
+  exit 1
+}
+
+if [[ ${EUID} -ne 0 ]]; then
+  die "запустите установщик через pkexec или sudo"
+fi
+
+TARGET_USER=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user)
+      [[ $# -ge 2 ]] || die "--user требует значение"
+      TARGET_USER="$2"
+      shift 2
+      ;;
+    *)
+      die "неизвестный параметр: $1"
+      ;;
+  esac
+done
+
+[[ -n ${TARGET_USER} ]] || die "обязателен --user <desktop-user>"
+TARGET_UID=$(id -u "${TARGET_USER}") || die "пользователь не найден"
+TARGET_GID=$(id -g "${TARGET_USER}") || die "primary group не найден"
+[[ ${TARGET_UID} -ne 0 ]] || die "desktop helper нельзя привязать к root"
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+GUI_ROOT=$(cd -- "${SCRIPT_DIR}/../../.." && pwd -P)
+SOURCE_PACKAGE="${GUI_ROOT}/xrayebator_gui"
+UNIT_SOURCE="${SCRIPT_DIR}/xrayebator-gui-helper.service"
+[[ -d ${SOURCE_PACKAGE} ]] || die "не найден пакет: ${SOURCE_PACKAGE}"
+[[ -f ${UNIT_SOURCE} ]] || die "не найден systemd unit"
+
+for command in curl unzip sha256sum nft systemctl python3; do
+  command -v "${command}" >/dev/null 2>&1 ||
+    die "не найдена зависимость '${command}'"
+done
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    XRAY_ASSET="Xray-linux-64.zip"
+    XRAY_SHA256="8195d909f1109b8f3d99eefe401a3c451d7bf4af71f24d3815420f77e5dd2a40"
+    ;;
+  aarch64|arm64)
+    XRAY_ASSET="Xray-linux-arm64-v8a.zip"
+    XRAY_SHA256="f5698bb218ada3b4022db26fafc39601c5f53b46b19eb76c9616325985807501"
+    ;;
+  *)
+    die "неподдерживаемая архитектура: $(uname -m)"
+    ;;
+esac
+
+STAGING=$(mktemp -d /tmp/xrayebator-helper.XXXXXXXXXX)
+cleanup() {
+  rm -rf -- "${STAGING}"
+}
+trap cleanup EXIT
+
+XRAY_URL="https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/${XRAY_ASSET}"
+echo "Загрузка Xray ${XRAY_VERSION} (${XRAY_ASSET})…"
+curl --fail --location --silent --show-error \
+  --connect-timeout 15 --max-time 300 \
+  "${XRAY_URL}" -o "${STAGING}/${XRAY_ASSET}"
+printf '%s  %s\n' "${XRAY_SHA256}" "${STAGING}/${XRAY_ASSET}" |
+  sha256sum --check --status ||
+  die "SHA-256 Xray не совпал"
+unzip -q "${STAGING}/${XRAY_ASSET}" xray -d "${STAGING}"
+"${STAGING}/xray" version | grep -F "Xray ${XRAY_VERSION#v}" >/dev/null ||
+  die "версия Xray не совпала с закреплённой"
+
+python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))' ||
+  die "требуется Python 3.10 или новее"
+
+systemctl stop xrayebator-gui-helper.service >/dev/null 2>&1 || true
+[[ ! -L ${INSTALL_ROOT} ]] || die "${INSTALL_ROOT} не должен быть symlink"
+[[ ! -L ${INSTALL_ROOT}/app ]] ||
+  die "${INSTALL_ROOT}/app не должен быть symlink"
+install -d -m 0755 -o root -g root "${INSTALL_ROOT}/app"
+install -d -m 0755 -o root -g root "${INSTALL_ROOT}/bin"
+find "${INSTALL_ROOT}/app" -mindepth 1 -delete
+
+while IFS= read -r -d '' source_file; do
+  relative_path=${source_file#"${GUI_ROOT}/"}
+  install -D -m 0644 -o root -g root \
+    "${source_file}" "${INSTALL_ROOT}/app/${relative_path}"
+done < <(find "${SOURCE_PACKAGE}" -type f -name '*.py' -print0)
+
+install -m 0755 -o root -g root "${STAGING}/xray" "${INSTALL_ROOT}/xray"
+cat >"${STAGING}/xrayebator-gui-helper" <<'WRAPPER'
+#!/bin/sh
+export PYTHONPATH=/opt/xrayebator-gui/app
+exec /usr/bin/python3 -m xrayebator_gui.helper.service "$@"
+WRAPPER
+install -m 0755 -o root -g root "${STAGING}/xrayebator-gui-helper" \
+  "${INSTALL_ROOT}/bin/xrayebator-gui-helper"
+
+install -d -m 0700 -o root -g root "${CONFIG_ROOT}"
+printf 'XRAYEBATOR_ALLOWED_UID=%s\nXRAYEBATOR_SOCKET_GID=%s\n' \
+  "${TARGET_UID}" "${TARGET_GID}" >"${CONFIG_ROOT}/helper.env"
+chown root:root "${CONFIG_ROOT}/helper.env"
+chmod 0600 "${CONFIG_ROOT}/helper.env"
+install -m 0644 -o root -g root "${UNIT_SOURCE}" "${SERVICE_PATH}"
+
+systemctl daemon-reload
+systemctl enable --now xrayebator-gui-helper.service
+systemctl is-active --quiet xrayebator-gui-helper.service ||
+  die "systemd helper не запустился; проверьте journalctl -u xrayebator-gui-helper"
+
+echo "Xrayebator TUN helper установлен для ${TARGET_USER} (UID ${TARGET_UID})."

--- a/gui/xrayebator_gui/resources/linux/install-helper.sh
+++ b/gui/xrayebator_gui/resources/linux/install-helper.sh
@@ -75,7 +75,7 @@ curl --fail --location --silent --show-error \
 printf '%s  %s\n' "${XRAY_SHA256}" "${STAGING}/${XRAY_ASSET}" |
   sha256sum --check --status ||
   die "SHA-256 Xray не совпал"
-unzip -q "${STAGING}/${XRAY_ASSET}" xray -d "${STAGING}"
+unzip -q "${STAGING}/${XRAY_ASSET}" xray geoip.dat geosite.dat -d "${STAGING}"
 "${STAGING}/xray" version | grep -F "Xray ${XRAY_VERSION#v}" >/dev/null ||
   die "версия Xray не совпала с закреплённой"
 
@@ -97,6 +97,10 @@ while IFS= read -r -d '' source_file; do
 done < <(find "${SOURCE_PACKAGE}" -type f -name '*.py' -print0)
 
 install -m 0755 -o root -g root "${STAGING}/xray" "${INSTALL_ROOT}/xray"
+install -m 0644 -o root -g root "${STAGING}/geoip.dat" \
+  "${INSTALL_ROOT}/geoip.dat"
+install -m 0644 -o root -g root "${STAGING}/geosite.dat" \
+  "${INSTALL_ROOT}/geosite.dat"
 cat >"${STAGING}/xrayebator-gui-helper" <<'WRAPPER'
 #!/bin/sh
 export PYTHONPATH=/opt/xrayebator-gui/app

--- a/gui/xrayebator_gui/resources/linux/xrayebator-gui-helper.service
+++ b/gui/xrayebator_gui/resources/linux/xrayebator-gui-helper.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Xrayebator privileged TUN helper
+Documentation=https://github.com/howdeploy/Xrayebator
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/xrayebator-gui/helper.env
+ExecStart=/opt/xrayebator-gui/bin/xrayebator-gui-helper --core /opt/xrayebator-gui/xray --allow-uid ${XRAYEBATOR_ALLOWED_UID} --socket-gid ${XRAYEBATOR_SOCKET_GID}
+Restart=on-failure
+RestartSec=2
+KillMode=control-group
+TimeoutStopSec=20
+UMask=0077
+
+User=root
+Group=root
+RuntimeDirectory=xrayebator-gui
+RuntimeDirectoryMode=0750
+StateDirectory=xrayebator-gui
+StateDirectoryMode=0700
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_CHOWN
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_CHOWN
+DeviceAllow=/dev/net/tun rw
+ReadWritePaths=/run/xrayebator-gui /var/lib/xrayebator-gui
+
+[Install]
+WantedBy=multi-user.target

--- a/gui/xrayebator_gui/ui/add_server_dialog.py
+++ b/gui/xrayebator_gui/ui/add_server_dialog.py
@@ -85,7 +85,7 @@ class AddServerDialog(QDialog):
 
         self.buttons = QDialogButtonBox()
         deploy_btn = self.buttons.addButton(
-            "Развернуть и добавить", QDialogButtonBox.ButtonRole.AcceptRole
+            "Развернуть и подключить", QDialogButtonBox.ButtonRole.AcceptRole
         )
         self.buttons.addButton(QDialogButtonBox.StandardButton.Cancel)
         deploy_btn.clicked.connect(self._on_accept)

--- a/gui/xrayebator_gui/ui/add_server_dialog.py
+++ b/gui/xrayebator_gui/ui/add_server_dialog.py
@@ -1,0 +1,144 @@
+"""Диалог добавления сервера: IP, SSH, пользователь, auth, email."""
+
+from __future__ import annotations
+
+import re
+
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+)
+
+_HOST_RE = re.compile(
+    r"^(?=.{1,253}$)("
+    r"(\d{1,3}\.){3}\d{1,3}"  # IPv4
+    r"|([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}"  # hostname
+    r")$"
+)
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def valid_host(host: str) -> bool:
+    """Проверка IPv4 или hostname перед отправкой на сервер."""
+    if not _HOST_RE.match(host):
+        return False
+    if re.match(r"^(\d{1,3}\.){3}\d{1,3}$", host):
+        return all(0 <= int(octet) <= 255 for octet in host.split("."))
+    return True
+
+
+def valid_email(email: str) -> bool:
+    return bool(_EMAIL_RE.match(email))
+
+
+class AddServerDialog(QDialog):
+    """Форма параметров VPS; «Развернуть и добавить» → accepted с данными."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Добавить сервер")
+        self.setMinimumWidth(420)
+
+        self.host_edit = QLineEdit()
+        self.host_edit.setPlaceholderText("203.0.113.10 или vpn.example.com")
+        self.port_spin = QSpinBox()
+        self.port_spin.setRange(1, 65535)
+        self.port_spin.setValue(22)
+        self.user_edit = QLineEdit("root")
+        self.auth_combo = QComboBox()
+        self.auth_combo.addItems(["Пароль", "SSH-ключ"])
+        self.password_edit = QLineEdit()
+        self.password_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.sudo_password_edit = QLineEdit()
+        self.sudo_password_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.sudo_password_edit.setPlaceholderText(
+            "необязательно: пусто = SSH-пароль или passwordless sudo"
+        )
+        self.key_edit = QLineEdit()
+        self.key_edit.setPlaceholderText("~/.ssh/id_ed25519")
+        key_browse = QPushButton("Обзор…")
+        key_browse.clicked.connect(self._browse_key)
+        key_row = QHBoxLayout()
+        key_row.addWidget(self.key_edit, 1)
+        key_row.addWidget(key_browse)
+        self.email_edit = QLineEdit()
+        self.email_edit.setPlaceholderText("you@example.com (для Let's Encrypt)")
+
+        form = QFormLayout()
+        form.addRow("Адрес сервера:", self.host_edit)
+        form.addRow("SSH порт:", self.port_spin)
+        form.addRow("Пользователь:", self.user_edit)
+        form.addRow("Аутентификация:", self.auth_combo)
+        form.addRow("Пароль:", self.password_edit)
+        form.addRow("Файл ключа:", key_row)
+        form.addRow("Пароль sudo:", self.sudo_password_edit)
+        form.addRow("Email:", self.email_edit)
+
+        self.buttons = QDialogButtonBox()
+        deploy_btn = self.buttons.addButton(
+            "Развернуть и добавить", QDialogButtonBox.ButtonRole.AcceptRole
+        )
+        self.buttons.addButton(QDialogButtonBox.StandardButton.Cancel)
+        deploy_btn.clicked.connect(self._on_accept)
+        self.buttons.rejected.connect(self.reject)
+
+        self.auth_combo.currentIndexChanged.connect(self._update_auth_fields)
+        self._update_auth_fields()
+
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(self.buttons)
+
+    def _update_auth_fields(self) -> None:
+        use_password = self.auth_combo.currentIndex() == 0
+        self.password_edit.setEnabled(use_password)
+        self.key_edit.setEnabled(not use_password)
+
+    def _browse_key(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Выберите приватный SSH-ключ", "", "Все файлы (*)"
+        )
+        if path:
+            self.key_edit.setText(path)
+
+    def _on_accept(self) -> None:
+        errors = []
+        if not valid_host(self.host_edit.text().strip()):
+            errors.append("Некорректный адрес сервера (IPv4 или hostname).")
+        if not self.user_edit.text().strip():
+            errors.append("Укажите пользователя SSH.")
+        if self.auth_combo.currentIndex() == 0:
+            if not self.password_edit.text():
+                errors.append("Укажите пароль.")
+        else:
+            if not self.key_edit.text().strip():
+                errors.append("Укажите путь к файлу SSH-ключа.")
+        if not valid_email(self.email_edit.text().strip()):
+            errors.append("Некорректный email (нужен для Let's Encrypt).")
+        if errors:
+            QMessageBox.warning(self, "Проверьте поля", "\n".join(errors))
+            return
+        self.accept()
+
+    def values(self) -> dict:
+        """Собранные и проверенные параметры формы."""
+        use_password = self.auth_combo.currentIndex() == 0
+        return {
+            "host": self.host_edit.text().strip(),
+            "port": self.port_spin.value(),
+            "user": self.user_edit.text().strip(),
+            "auth_type": "password" if use_password else "key",
+            "password": self.password_edit.text() if use_password else None,
+            "key_path": self.key_edit.text().strip() if not use_password else None,
+            "sudo_password": self.sudo_password_edit.text() or None,
+            "email": self.email_edit.text().strip(),
+        }

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -117,6 +117,7 @@ class MainWindow(QMainWindow):
         self._latencies: dict[str, Optional[int]] = {}
         self._operation: Optional[OperationThread] = None
         self._deploy_thread: Optional[QThread] = None
+        self._connect_after_route_load = False
         self._quitting = False
 
         self._build_ui()
@@ -360,6 +361,7 @@ class MainWindow(QMainWindow):
     def _routes_failed(self, message: str) -> None:
         self._routes = []
         self._latencies = {}
+        self._connect_after_route_load = False
         self.route_combo.clear()
         self.route_combo.addItem("Не удалось загрузить маршруты")
         self._append_log(f"Ошибка подписки: {message}")
@@ -450,6 +452,7 @@ class MainWindow(QMainWindow):
             profile=result.get("profile", "happ"),
         )
         self._append_log("Сервер добавлен, subscription получена и сохранена.")
+        self._connect_after_route_load = True
         self._reload_servers(select_id=server["id"])
 
     def _deployment_failed(self, message: str) -> None:
@@ -458,7 +461,7 @@ class MainWindow(QMainWindow):
 
     def _deployment_thread_finished(self) -> None:
         self._deploy_thread = None
-        self._set_operation_busy(False)
+        self._set_operation_busy(self._operation is not None)
         self._on_snapshot(self._controller.snapshot)
 
     @Slot()
@@ -637,6 +640,9 @@ class MainWindow(QMainWindow):
 
     def _operation_finished(self) -> None:
         self._operation = None
+        if self._connect_after_route_load and self._selected_route() is not None:
+            self._connect_after_route_load = False
+            self._toggle_connection()
 
     def _set_operation_busy(self, busy: bool) -> None:
         self.add_server_button.setEnabled(not busy)

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Callable, Optional
 
-from PySide6.QtCore import QObject, QThread, Qt, Signal, Slot
+from PySide6.QtCore import QObject, QThread, Signal, Slot
 from PySide6.QtGui import QAction, QCloseEvent, QIcon
 from PySide6.QtWidgets import (
     QComboBox,
@@ -26,10 +26,9 @@ from ..core.connection import (
     ConnectionMode,
     ConnectionSnapshot,
     ConnectionState,
-    RouteSwitchError,
 )
 from ..core.deploy import STEPS, make_deploy_thread
-from ..core.local_proxy import LocalProxyBackend
+from ..core.desktop_backend import DesktopBackend
 from ..core.servers import ServerStore
 from ..core.ssh import SSHClient
 from ..core import subscription
@@ -43,7 +42,9 @@ class OperationThread(QThread):
     succeeded = Signal(object)
     failed = Signal(str)
 
-    def __init__(self, operation: Callable[[], object], parent: Optional[QObject] = None):
+    def __init__(
+        self, operation: Callable[[], object], parent: Optional[QObject] = None
+    ):
         super().__init__(parent)
         self._operation = operation
 
@@ -96,7 +97,13 @@ class MainWindow(QMainWindow):
         self.resize(760, 540)
 
         self._store = store or ServerStore()
-        self._controller = controller or ConnectionController(LocalProxyBackend())
+        if controller is None:
+            desktop_backend = DesktopBackend()
+            self._controller = ConnectionController(desktop_backend)
+            self._tun_available = desktop_backend.tun_available
+        else:
+            self._controller = controller
+            self._tun_available = False
         self._bridge = _ConnectionBridge(self)
         self._controller.subscribe(self._bridge.snapshot_changed.emit)
         self._bridge.snapshot_changed.connect(self._on_snapshot)
@@ -145,14 +152,19 @@ class MainWindow(QMainWindow):
 
         form = QFormLayout()
         self.mode_combo = QComboBox()
-        self.mode_combo.addItem("TUN — в разработке", ConnectionMode.TUN)
+        tun_label = (
+            "TUN (native Xray)"
+            if self._tun_available
+            else "TUN — privileged helper не установлен"
+        )
+        self.mode_combo.addItem(tun_label, ConnectionMode.TUN)
         tun_item = self.mode_combo.model().item(0)
-        if tun_item is not None:
+        if tun_item is not None and not self._tun_available:
             tun_item.setEnabled(False)
         self.mode_combo.addItem(
             "Системный proxy (текущий MVP)", ConnectionMode.SYSTEM_PROXY
         )
-        self.mode_combo.setCurrentIndex(1)
+        self.mode_combo.setCurrentIndex(0 if self._tun_available else 1)
         form.addRow("Режим:", self.mode_combo)
 
         route_row = QHBoxLayout()
@@ -271,7 +283,9 @@ class MainWindow(QMainWindow):
         def load() -> list[VlessLink]:
             routes = subscription.parse(subscription.fetch(url))
             if not routes:
-                raise RuntimeError("Подписка не содержит поддерживаемых VLESS-маршрутов")
+                raise RuntimeError(
+                    "Подписка не содержит поддерживаемых VLESS-маршрутов"
+                )
             return routes
 
         self._start_operation(load, self._routes_loaded, self._routes_failed)
@@ -320,9 +334,7 @@ class MainWindow(QMainWindow):
         )
         self._deploy_thread = thread
         thread.step_changed.connect(
-            lambda index, name: self._append_log(
-                f"[{index + 1}/{len(STEPS)}] {name}"
-            )
+            lambda index, name: self._append_log(f"[{index + 1}/{len(STEPS)}] {name}")
         )
         thread.log_line.connect(self._append_log)
         thread.finished_ok.connect(
@@ -344,9 +356,7 @@ class MainWindow(QMainWindow):
             subscription_url=result["subscription_url"],
             profile=result.get("profile", "happ"),
         )
-        self._append_log(
-            f"Сервер добавлен. Подписка: {result['subscription_url']}"
-        )
+        self._append_log(f"Сервер добавлен. Подписка: {result['subscription_url']}")
         self._reload_servers(select_id=server["id"])
 
     def _deployment_failed(self, message: str) -> None:
@@ -390,9 +400,7 @@ class MainWindow(QMainWindow):
         mode = self.mode_combo.currentData()
         if not isinstance(mode, ConnectionMode):
             mode = ConnectionMode(mode)
-        self._start_connection_operation(
-            lambda: self._controller.connect(route, mode)
-        )
+        self._start_connection_operation(lambda: self._controller.connect(route, mode))
 
     @Slot()
     def _switch_route(self) -> None:

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -29,6 +29,7 @@ from ..core.connection import (
 )
 from ..core.deploy import STEPS, make_deploy_thread
 from ..core.desktop_backend import DesktopBackend
+from ..core.helper_install import install_linux_helper
 from ..core.servers import ServerStore
 from ..core.ssh import SSHClient
 from ..core import subscription
@@ -97,8 +98,10 @@ class MainWindow(QMainWindow):
         self.resize(760, 540)
 
         self._store = store or ServerStore()
+        self._desktop_backend: Optional[DesktopBackend] = None
         if controller is None:
             desktop_backend = DesktopBackend()
+            self._desktop_backend = desktop_backend
             self._controller = ConnectionController(desktop_backend)
             self._tun_available = desktop_backend.tun_available
         else:
@@ -151,6 +154,7 @@ class MainWindow(QMainWindow):
         layout.addLayout(server_row)
 
         form = QFormLayout()
+        mode_row = QHBoxLayout()
         self.mode_combo = QComboBox()
         tun_label = (
             "TUN (native Xray)"
@@ -165,7 +169,14 @@ class MainWindow(QMainWindow):
             "Системный proxy (текущий MVP)", ConnectionMode.SYSTEM_PROXY
         )
         self.mode_combo.setCurrentIndex(0 if self._tun_available else 1)
-        form.addRow("Режим:", self.mode_combo)
+        mode_row.addWidget(self.mode_combo, 1)
+        self.install_helper_button = QPushButton("Установить TUN helper…")
+        self.install_helper_button.setVisible(
+            self._desktop_backend is not None and not self._tun_available
+        )
+        self.install_helper_button.clicked.connect(self._install_tun_helper)
+        mode_row.addWidget(self.install_helper_button)
+        form.addRow("Режим:", mode_row)
 
         route_row = QHBoxLayout()
         self.route_combo = QComboBox()
@@ -344,6 +355,44 @@ class MainWindow(QMainWindow):
         thread.finished.connect(self._deployment_thread_finished)
         thread.start()
 
+    @Slot()
+    def _install_tun_helper(self) -> None:
+        if self._operation is not None:
+            return
+        self._append_log("Запрашиваю права для установки TUN helper…")
+        self._set_operation_busy(True)
+
+        def succeeded(result: object) -> None:
+            self._set_operation_busy(False)
+            if self._desktop_backend is None or not self._desktop_backend.tun_available:
+                message = (
+                    "Installer завершился, но helper socket недоступен. "
+                    "Проверьте systemctl status xrayebator-gui-helper."
+                )
+                self._append_log(message)
+                QMessageBox.warning(self, "TUN helper", message)
+                return
+            self._tun_available = True
+            tun_item = self.mode_combo.model().item(0)
+            if tun_item is not None:
+                tun_item.setEnabled(True)
+            self.mode_combo.setItemText(0, "TUN (native Xray)")
+            self.mode_combo.setCurrentIndex(0)
+            self.install_helper_button.hide()
+            self._append_log(str(result))
+            QMessageBox.information(
+                self,
+                "TUN helper",
+                "Privileged helper установлен. Режим TUN готов к подключению.",
+            )
+
+        def failed(message: str) -> None:
+            self._set_operation_busy(False)
+            self._append_log(f"Установка TUN helper не удалась: {message}")
+            QMessageBox.critical(self, "Ошибка установки TUN helper", message)
+
+        self._start_operation(install_linux_helper, succeeded, failed)
+
     def _deployment_finished(self, values: dict, result: dict) -> None:
         server = self._store.add(
             name=values["host"],
@@ -470,6 +519,7 @@ class MainWindow(QMainWindow):
         self.server_combo.setEnabled(not busy)
         self.mode_combo.setEnabled(not busy)
         self.refresh_button.setEnabled(not busy and self._selected_server() is not None)
+        self.install_helper_button.setEnabled(not busy)
 
     @Slot(object)
     def _on_snapshot(self, snapshot: ConnectionSnapshot) -> None:

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import platform
 from typing import Callable, Optional
 
 from PySide6.QtCore import QObject, QThread, Signal, Slot
@@ -160,11 +161,12 @@ class MainWindow(QMainWindow):
         form = QFormLayout()
         mode_row = QHBoxLayout()
         self.mode_combo = QComboBox()
-        tun_label = (
-            "TUN (native Xray)"
-            if self._tun_available
-            else "TUN — privileged helper не установлен"
-        )
+        if self._tun_available:
+            tun_label = "TUN (native Xray)"
+        elif platform.system() == "Linux":
+            tun_label = "TUN — privileged helper не установлен"
+        else:
+            tun_label = "TUN — готовится для этой ОС"
         self.mode_combo.addItem(tun_label, ConnectionMode.TUN)
         tun_item = self.mode_combo.model().item(0)
         if tun_item is not None and not self._tun_available:
@@ -176,7 +178,9 @@ class MainWindow(QMainWindow):
         mode_row.addWidget(self.mode_combo, 1)
         self.install_helper_button = QPushButton("Установить TUN helper…")
         self.install_helper_button.setVisible(
-            self._desktop_backend is not None and not self._tun_available
+            platform.system() == "Linux"
+            and self._desktop_backend is not None
+            and not self._tun_available
         )
         self.install_helper_button.clicked.connect(self._install_tun_helper)
         mode_row.addWidget(self.install_helper_button)

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -30,6 +30,7 @@ from ..core.connection import (
 from ..core.deploy import STEPS, make_deploy_thread
 from ..core.desktop_backend import DesktopBackend
 from ..core.helper_install import install_linux_helper
+from ..core.routing import RoutingProfile
 from ..core.servers import ServerStore
 from ..core.ssh import SSHClient
 from ..core import subscription
@@ -178,6 +179,17 @@ class MainWindow(QMainWindow):
         mode_row.addWidget(self.install_helper_button)
         form.addRow("Режим:", mode_row)
 
+        profile_row = QHBoxLayout()
+        self.profile_combo = QComboBox()
+        for profile in RoutingProfile:
+            self.profile_combo.addItem(profile.label, profile)
+        self.profile_combo.currentIndexChanged.connect(self._on_profile_selected)
+        profile_row.addWidget(self.profile_combo, 1)
+        self.profile_switch_button = QPushButton("Применить")
+        self.profile_switch_button.clicked.connect(self._switch_profile)
+        profile_row.addWidget(self.profile_switch_button)
+        form.addRow("Профиль:", profile_row)
+
         route_row = QHBoxLayout()
         self.route_combo = QComboBox()
         route_row.addWidget(self.route_combo, 1)
@@ -262,6 +274,12 @@ class MainWindow(QMainWindow):
         if 0 <= index < len(self._routes):
             return self._routes[index]
         return None
+
+    def _selected_profile(self) -> RoutingProfile:
+        profile = self.profile_combo.currentData()
+        return (
+            profile if isinstance(profile, RoutingProfile) else RoutingProfile(profile)
+        )
 
     @Slot()
     def _server_changed(self) -> None:
@@ -449,7 +467,10 @@ class MainWindow(QMainWindow):
         mode = self.mode_combo.currentData()
         if not isinstance(mode, ConnectionMode):
             mode = ConnectionMode(mode)
-        self._start_connection_operation(lambda: self._controller.connect(route, mode))
+        profile = self._selected_profile()
+        self._start_connection_operation(
+            lambda: self._controller.connect(route, mode, profile)
+        )
 
     @Slot()
     def _switch_route(self) -> None:
@@ -467,6 +488,20 @@ class MainWindow(QMainWindow):
             lambda: self._controller.switch_route(route),
             switch=True,
         )
+
+    @Slot()
+    def _switch_profile(self) -> None:
+        if self._controller.snapshot.state != ConnectionState.CONNECTED:
+            return
+        profile = self._selected_profile()
+        self._start_connection_operation(
+            lambda: self._controller.switch_profile(profile),
+            switch=True,
+        )
+
+    @Slot()
+    def _on_profile_selected(self) -> None:
+        self._on_snapshot(self._controller.snapshot)
 
     def _start_connection_operation(
         self, operation: Callable[[], object], *, switch: bool = False
@@ -518,6 +553,7 @@ class MainWindow(QMainWindow):
         self.add_server_button.setEnabled(not busy)
         self.server_combo.setEnabled(not busy)
         self.mode_combo.setEnabled(not busy)
+        self.profile_combo.setEnabled(not busy)
         self.refresh_button.setEnabled(not busy and self._selected_server() is not None)
         self.install_helper_button.setEnabled(not busy)
 
@@ -530,12 +566,24 @@ class MainWindow(QMainWindow):
         )
         connected = snapshot.state == ConnectionState.CONNECTED
         busy = snapshot.state in _BUSY_STATES
+        if snapshot.routing_profile is not None and (busy or snapshot.error):
+            for index in range(self.profile_combo.count()):
+                if self.profile_combo.itemData(index) == snapshot.routing_profile:
+                    self.profile_combo.blockSignals(True)
+                    self.profile_combo.setCurrentIndex(index)
+                    self.profile_combo.blockSignals(False)
+                    break
         self.connect_button.setText("Отключить" if connected else "Подключить")
         self.connect_button.setEnabled(
             not busy and (connected or self._selected_route() is not None)
         )
         self.switch_button.setEnabled(
             connected and self._selected_route() is not None and not busy
+        )
+        self.profile_switch_button.setEnabled(
+            connected
+            and not busy
+            and self._selected_profile() != snapshot.routing_profile
         )
         self.tray_toggle_action.setText("Отключить" if connected else "Подключить")
         self.tray_toggle_action.setEnabled(not busy)

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -236,12 +236,16 @@ class MainWindow(QMainWindow):
         self.tray_toggle_action = QAction("Подключить", self)
         self.tray_toggle_action.triggered.connect(self._toggle_connection)
         menu.addAction(self.tray_toggle_action)
+        self.tray_server_menu = menu.addMenu("Сервер")
+        self.tray_route_menu = menu.addMenu("Маршрут")
+        self.tray_profile_menu = menu.addMenu("Профиль")
         menu.addSeparator()
         quit_action = QAction("Выйти", self)
         quit_action.triggered.connect(self._quit)
         menu.addAction(quit_action)
         self.tray.setContextMenu(menu)
         self.tray.show()
+        self._refresh_tray_menus()
 
     def _append_log(self, text: str) -> None:
         self.log.append(text)
@@ -263,6 +267,7 @@ class MainWindow(QMainWindow):
                 if data and data.get("id") == select_id:
                     self.server_combo.setCurrentIndex(index)
                     break
+        self._refresh_tray_menus()
         self._server_changed()
 
     def _selected_server(self) -> Optional[dict]:
@@ -293,6 +298,7 @@ class MainWindow(QMainWindow):
             self._refresh_routes()
         else:
             self.route_combo.addItem("Сначала добавьте VPS")
+        self._refresh_tray_menus()
         self._on_snapshot(self._controller.snapshot)
 
     @Slot()
@@ -330,6 +336,7 @@ class MainWindow(QMainWindow):
         if default is not None:
             self.route_combo.setCurrentIndex(routes.index(default))
         self._append_log(f"Подписка обновлена: {len(routes)} маршрутов")
+        self._refresh_tray_menus()
         self._set_operation_busy(False)
         self._on_snapshot(self._controller.snapshot)
 
@@ -338,6 +345,7 @@ class MainWindow(QMainWindow):
         self.route_combo.clear()
         self.route_combo.addItem("Не удалось загрузить маршруты")
         self._append_log(f"Ошибка подписки: {message}")
+        self._refresh_tray_menus()
         self._set_operation_busy(False)
         QMessageBox.warning(self, "Ошибка подписки", message)
         self._on_snapshot(self._controller.snapshot)
@@ -423,7 +431,7 @@ class MainWindow(QMainWindow):
             subscription_url=result["subscription_url"],
             profile=result.get("profile", "happ"),
         )
-        self._append_log(f"Сервер добавлен. Подписка: {result['subscription_url']}")
+        self._append_log("Сервер добавлен, subscription получена и сохранена.")
         self._reload_servers(select_id=server["id"])
 
     def _deployment_failed(self, message: str) -> None:
@@ -501,7 +509,70 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def _on_profile_selected(self) -> None:
+        self._refresh_tray_menus()
         self._on_snapshot(self._controller.snapshot)
+
+    def _select_server_from_tray(self, index: int) -> None:
+        if 0 <= index < self.server_combo.count():
+            self.server_combo.setCurrentIndex(index)
+
+    def _select_route_from_tray(self, index: int) -> None:
+        if not 0 <= index < len(self._routes):
+            return
+        self.route_combo.setCurrentIndex(index)
+        if self._controller.snapshot.state == ConnectionState.CONNECTED:
+            self._switch_route()
+        else:
+            self._refresh_tray_menus()
+
+    def _select_profile_from_tray(self, profile: RoutingProfile) -> None:
+        for index in range(self.profile_combo.count()):
+            if self.profile_combo.itemData(index) == profile:
+                self.profile_combo.setCurrentIndex(index)
+                break
+        if self._controller.snapshot.state == ConnectionState.CONNECTED:
+            self._switch_profile()
+        else:
+            self._refresh_tray_menus()
+
+    def _refresh_tray_menus(self) -> None:
+        if not hasattr(self, "tray_server_menu"):
+            return
+        self.tray_server_menu.clear()
+        for index in range(self.server_combo.count()):
+            action = self.tray_server_menu.addAction(self.server_combo.itemText(index))
+            action.setCheckable(True)
+            action.setChecked(index == self.server_combo.currentIndex())
+            action.triggered.connect(
+                lambda checked=False, selected=index: (
+                    self._select_server_from_tray(selected)
+                )
+            )
+        self.tray_server_menu.setEnabled(self.server_combo.count() > 0)
+
+        self.tray_route_menu.clear()
+        for index, route in enumerate(self._routes):
+            action = self.tray_route_menu.addAction(route.remark or route.label)
+            action.setCheckable(True)
+            action.setChecked(index == self.route_combo.currentIndex())
+            action.triggered.connect(
+                lambda checked=False, selected=index: (
+                    self._select_route_from_tray(selected)
+                )
+            )
+        self.tray_route_menu.setEnabled(bool(self._routes))
+
+        self.tray_profile_menu.clear()
+        selected_profile = self._selected_profile()
+        for profile in RoutingProfile:
+            action = self.tray_profile_menu.addAction(profile.label)
+            action.setCheckable(True)
+            action.setChecked(profile == selected_profile)
+            action.triggered.connect(
+                lambda checked=False, selected=profile: (
+                    self._select_profile_from_tray(selected)
+                )
+            )
 
     def _start_connection_operation(
         self, operation: Callable[[], object], *, switch: bool = False
@@ -566,6 +637,11 @@ class MainWindow(QMainWindow):
         )
         connected = snapshot.state == ConnectionState.CONNECTED
         busy = snapshot.state in _BUSY_STATES
+        if snapshot.route is not None and (busy or snapshot.error):
+            for index, route in enumerate(self._routes):
+                if route.raw == snapshot.route.raw:
+                    self.route_combo.setCurrentIndex(index)
+                    break
         if snapshot.routing_profile is not None and (busy or snapshot.error):
             for index in range(self.profile_combo.count()):
                 if self.profile_combo.itemData(index) == snapshot.routing_profile:
@@ -587,7 +663,14 @@ class MainWindow(QMainWindow):
         )
         self.tray_toggle_action.setText("Отключить" if connected else "Подключить")
         self.tray_toggle_action.setEnabled(not busy)
-        self.tray.setToolTip(f"Xrayebator — {label.lower()}")
+        target = ""
+        if snapshot.route is not None and snapshot.routing_profile is not None:
+            target = (
+                f"\n{snapshot.route.remark or snapshot.route.label}"
+                f" · {snapshot.routing_profile.label}"
+            )
+        self.tray.setToolTip(f"Xrayebator — {label.lower()}{target}")
+        self._refresh_tray_menus()
         if snapshot.error and snapshot.state == ConnectionState.ERROR:
             self.status_label.setToolTip(snapshot.error)
         else:

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -1,0 +1,528 @@
+"""Main desktop window, tray integration, deployment and connection controls."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from PySide6.QtCore import QObject, QThread, Qt, Signal, Slot
+from PySide6.QtGui import QAction, QCloseEvent, QIcon
+from PySide6.QtWidgets import (
+    QComboBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSystemTrayIcon,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+    QMenu,
+)
+
+from ..core.connection import (
+    ConnectionController,
+    ConnectionMode,
+    ConnectionSnapshot,
+    ConnectionState,
+    RouteSwitchError,
+)
+from ..core.deploy import STEPS, make_deploy_thread
+from ..core.local_proxy import LocalProxyBackend
+from ..core.servers import ServerStore
+from ..core.ssh import SSHClient
+from ..core import subscription
+from ..core.subscription import VlessLink
+from .add_server_dialog import AddServerDialog
+
+
+class OperationThread(QThread):
+    """Run one blocking Python callable without freezing Qt."""
+
+    succeeded = Signal(object)
+    failed = Signal(str)
+
+    def __init__(self, operation: Callable[[], object], parent: Optional[QObject] = None):
+        super().__init__(parent)
+        self._operation = operation
+
+    def run(self) -> None:
+        try:
+            result = self._operation()
+        except Exception as exc:  # noqa: BLE001 - surface operation error to UI
+            self.failed.emit(str(exc))
+            return
+        self.succeeded.emit(result)
+
+
+class _ConnectionBridge(QObject):
+    snapshot_changed = Signal(object)
+
+
+_STATE_LABELS = {
+    ConnectionState.DISCONNECTED: "Отключено",
+    ConnectionState.PREPARING: "Подготовка…",
+    ConnectionState.CONNECTING: "Подключение…",
+    ConnectionState.VERIFYING: "Проверка туннеля…",
+    ConnectionState.CONNECTED: "Подключено",
+    ConnectionState.SWITCHING: "Переключение маршрута…",
+    ConnectionState.DISCONNECTING: "Отключение…",
+    ConnectionState.RECOVERING: "Восстановление предыдущего маршрута…",
+    ConnectionState.ERROR: "Ошибка",
+}
+
+_BUSY_STATES = {
+    ConnectionState.PREPARING,
+    ConnectionState.CONNECTING,
+    ConnectionState.VERIFYING,
+    ConnectionState.SWITCHING,
+    ConnectionState.DISCONNECTING,
+    ConnectionState.RECOVERING,
+}
+
+
+class MainWindow(QMainWindow):
+    def __init__(
+        self,
+        *,
+        icon: QIcon,
+        store: Optional[ServerStore] = None,
+        controller: Optional[ConnectionController] = None,
+    ):
+        super().__init__()
+        self.setWindowTitle("Xrayebator")
+        self.setWindowIcon(icon)
+        self.resize(760, 540)
+
+        self._store = store or ServerStore()
+        self._controller = controller or ConnectionController(LocalProxyBackend())
+        self._bridge = _ConnectionBridge(self)
+        self._controller.subscribe(self._bridge.snapshot_changed.emit)
+        self._bridge.snapshot_changed.connect(self._on_snapshot)
+
+        self._routes: list[VlessLink] = []
+        self._operation: Optional[OperationThread] = None
+        self._deploy_thread: Optional[QThread] = None
+        self._quitting = False
+
+        self._build_ui()
+        self._build_tray(icon)
+        self._reload_servers()
+        self._on_snapshot(self._controller.snapshot)
+
+    def _build_ui(self) -> None:
+        root = QWidget()
+        self.setCentralWidget(root)
+        layout = QVBoxLayout(root)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(14)
+
+        title = QLabel("Xrayebator")
+        title_font = title.font()
+        title_font.setPointSize(20)
+        title_font.setBold(True)
+        title.setFont(title_font)
+        layout.addWidget(title)
+
+        subtitle = QLabel(
+            "Разверните собственный сервер, выберите маршрут и подключитесь."
+        )
+        subtitle.setStyleSheet("color: #a0a0a0")
+        layout.addWidget(subtitle)
+
+        server_row = QHBoxLayout()
+        self.server_combo = QComboBox()
+        self.server_combo.currentIndexChanged.connect(self._server_changed)
+        server_row.addWidget(self.server_combo, 1)
+        self.add_server_button = QPushButton("Добавить VPS…")
+        self.add_server_button.clicked.connect(self._add_server)
+        server_row.addWidget(self.add_server_button)
+        self.remove_server_button = QPushButton("Удалить")
+        self.remove_server_button.clicked.connect(self._remove_server)
+        server_row.addWidget(self.remove_server_button)
+        layout.addLayout(server_row)
+
+        form = QFormLayout()
+        self.mode_combo = QComboBox()
+        self.mode_combo.addItem("TUN — в разработке", ConnectionMode.TUN)
+        tun_item = self.mode_combo.model().item(0)
+        if tun_item is not None:
+            tun_item.setEnabled(False)
+        self.mode_combo.addItem(
+            "Системный proxy (текущий MVP)", ConnectionMode.SYSTEM_PROXY
+        )
+        self.mode_combo.setCurrentIndex(1)
+        form.addRow("Режим:", self.mode_combo)
+
+        route_row = QHBoxLayout()
+        self.route_combo = QComboBox()
+        route_row.addWidget(self.route_combo, 1)
+        self.refresh_button = QPushButton("Обновить")
+        self.refresh_button.clicked.connect(self._refresh_routes)
+        route_row.addWidget(self.refresh_button)
+        self.switch_button = QPushButton("Переключить")
+        self.switch_button.clicked.connect(self._switch_route)
+        route_row.addWidget(self.switch_button)
+        form.addRow("Маршрут:", route_row)
+        layout.addLayout(form)
+
+        status_row = QHBoxLayout()
+        self.status_label = QLabel("Отключено")
+        status_font = self.status_label.font()
+        status_font.setBold(True)
+        self.status_label.setFont(status_font)
+        status_row.addWidget(self.status_label)
+        status_row.addStretch()
+        self.ip_label = QLabel("")
+        self.ip_label.setStyleSheet("color: #a0a0a0")
+        status_row.addWidget(self.ip_label)
+        layout.addLayout(status_row)
+
+        self.connect_button = QPushButton("Подключить")
+        self.connect_button.setMinimumHeight(52)
+        self.connect_button.clicked.connect(self._toggle_connection)
+        layout.addWidget(self.connect_button)
+
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        self.log.setPlaceholderText("Здесь появятся этапы развёртывания и подключения.")
+        layout.addWidget(self.log, 1)
+
+    def _build_tray(self, icon: QIcon) -> None:
+        self.tray = QSystemTrayIcon(icon, self)
+        self.tray.setToolTip("Xrayebator — отключено")
+        self.tray.activated.connect(self._tray_activated)
+
+        menu = QMenu(self)
+        show_action = QAction("Открыть Xrayebator", self)
+        show_action.triggered.connect(self._show_window)
+        menu.addAction(show_action)
+        self.tray_toggle_action = QAction("Подключить", self)
+        self.tray_toggle_action.triggered.connect(self._toggle_connection)
+        menu.addAction(self.tray_toggle_action)
+        menu.addSeparator()
+        quit_action = QAction("Выйти", self)
+        quit_action.triggered.connect(self._quit)
+        menu.addAction(quit_action)
+        self.tray.setContextMenu(menu)
+        self.tray.show()
+
+    def _append_log(self, text: str) -> None:
+        self.log.append(text)
+
+    def _reload_servers(self, select_id: Optional[str] = None) -> None:
+        self.server_combo.blockSignals(True)
+        self.server_combo.clear()
+        servers = self._store.list()
+        for server in servers:
+            self.server_combo.addItem(
+                server.get("name") or server.get("host") or "Сервер",
+                server,
+            )
+        self.server_combo.blockSignals(False)
+
+        if select_id:
+            for index in range(self.server_combo.count()):
+                data = self.server_combo.itemData(index)
+                if data and data.get("id") == select_id:
+                    self.server_combo.setCurrentIndex(index)
+                    break
+        self._server_changed()
+
+    def _selected_server(self) -> Optional[dict]:
+        data = self.server_combo.currentData()
+        return data if isinstance(data, dict) else None
+
+    def _selected_route(self) -> Optional[VlessLink]:
+        index = self.route_combo.currentIndex()
+        if 0 <= index < len(self._routes):
+            return self._routes[index]
+        return None
+
+    @Slot()
+    def _server_changed(self) -> None:
+        self._routes = []
+        self.route_combo.clear()
+        server = self._selected_server()
+        enabled = server is not None
+        self.remove_server_button.setEnabled(enabled)
+        self.refresh_button.setEnabled(enabled)
+        if enabled:
+            self._refresh_routes()
+        else:
+            self.route_combo.addItem("Сначала добавьте VPS")
+        self._on_snapshot(self._controller.snapshot)
+
+    @Slot()
+    def _refresh_routes(self) -> None:
+        server = self._selected_server()
+        if not server or self._operation is not None:
+            return
+        url = server.get("subscription_url", "")
+        if not url:
+            QMessageBox.warning(self, "Нет подписки", "У сервера нет subscription URL.")
+            return
+
+        self.route_combo.clear()
+        self.route_combo.addItem("Загрузка подписки…")
+        self._set_operation_busy(True)
+
+        def load() -> list[VlessLink]:
+            routes = subscription.parse(subscription.fetch(url))
+            if not routes:
+                raise RuntimeError("Подписка не содержит поддерживаемых VLESS-маршрутов")
+            return routes
+
+        self._start_operation(load, self._routes_loaded, self._routes_failed)
+
+    def _routes_loaded(self, result: object) -> None:
+        routes = list(result) if isinstance(result, list) else []
+        self._routes = routes
+        self.route_combo.clear()
+        for route in routes:
+            label = route.remark or route.label
+            self.route_combo.addItem(f"{label} — {route.label}")
+        default = subscription.pick_default(routes)
+        if default is not None:
+            self.route_combo.setCurrentIndex(routes.index(default))
+        self._append_log(f"Подписка обновлена: {len(routes)} маршрутов")
+        self._set_operation_busy(False)
+        self._on_snapshot(self._controller.snapshot)
+
+    def _routes_failed(self, message: str) -> None:
+        self._routes = []
+        self.route_combo.clear()
+        self.route_combo.addItem("Не удалось загрузить маршруты")
+        self._append_log(f"Ошибка подписки: {message}")
+        self._set_operation_busy(False)
+        QMessageBox.warning(self, "Ошибка подписки", message)
+        self._on_snapshot(self._controller.snapshot)
+
+    @Slot()
+    def _add_server(self) -> None:
+        dialog = AddServerDialog(self)
+        if dialog.exec() != AddServerDialog.DialogCode.Accepted:
+            return
+        values = dialog.values()
+        self._append_log(f"Начинаю развёртывание на {values['host']}…")
+        self._set_operation_busy(True)
+
+        thread = make_deploy_thread(
+            ssh_client=SSHClient(),
+            host=values["host"],
+            port=values["port"],
+            user=values["user"],
+            password=values["password"],
+            key_path=values["key_path"],
+            sudo_password=values["sudo_password"],
+            email=values["email"],
+        )
+        self._deploy_thread = thread
+        thread.step_changed.connect(
+            lambda index, name: self._append_log(
+                f"[{index + 1}/{len(STEPS)}] {name}"
+            )
+        )
+        thread.log_line.connect(self._append_log)
+        thread.finished_ok.connect(
+            lambda result: self._deployment_finished(values, result)
+        )
+        thread.failed.connect(self._deployment_failed)
+        thread.finished.connect(self._deployment_thread_finished)
+        thread.start()
+
+    def _deployment_finished(self, values: dict, result: dict) -> None:
+        server = self._store.add(
+            name=values["host"],
+            host=values["host"],
+            port=values["port"],
+            user=values["user"],
+            auth_type=values["auth_type"],
+            password=values["password"],
+            key_path=values["key_path"],
+            subscription_url=result["subscription_url"],
+            profile=result.get("profile", "happ"),
+        )
+        self._append_log(
+            f"Сервер добавлен. Подписка: {result['subscription_url']}"
+        )
+        self._reload_servers(select_id=server["id"])
+
+    def _deployment_failed(self, message: str) -> None:
+        self._append_log(f"Развёртывание не удалось: {message}")
+        QMessageBox.critical(self, "Ошибка развёртывания", message)
+
+    def _deployment_thread_finished(self) -> None:
+        self._deploy_thread = None
+        self._set_operation_busy(False)
+        self._on_snapshot(self._controller.snapshot)
+
+    @Slot()
+    def _remove_server(self) -> None:
+        server = self._selected_server()
+        if not server:
+            return
+        answer = QMessageBox.question(
+            self,
+            "Удалить сервер?",
+            f"Удалить {server.get('name') or server.get('host')} из приложения?\n"
+            "Конфигурация VPS изменена не будет.",
+        )
+        if answer != QMessageBox.StandardButton.Yes:
+            return
+        self._store.remove(server["id"])
+        self._reload_servers()
+
+    @Slot()
+    def _toggle_connection(self) -> None:
+        state = self._controller.snapshot.state
+        if state in _BUSY_STATES or self._operation is not None:
+            return
+        if state == ConnectionState.CONNECTED:
+            self._start_connection_operation(self._controller.disconnect)
+            return
+
+        route = self._selected_route()
+        if route is None:
+            QMessageBox.warning(self, "Нет маршрута", "Сначала загрузите подписку.")
+            return
+        mode = self.mode_combo.currentData()
+        if not isinstance(mode, ConnectionMode):
+            mode = ConnectionMode(mode)
+        self._start_connection_operation(
+            lambda: self._controller.connect(route, mode)
+        )
+
+    @Slot()
+    def _switch_route(self) -> None:
+        route = self._selected_route()
+        if route is None:
+            return
+        if self._controller.snapshot.state != ConnectionState.CONNECTED:
+            QMessageBox.information(
+                self,
+                "Маршрут выбран",
+                "Маршрут будет использован при следующем подключении.",
+            )
+            return
+        self._start_connection_operation(
+            lambda: self._controller.switch_route(route),
+            switch=True,
+        )
+
+    def _start_connection_operation(
+        self, operation: Callable[[], object], *, switch: bool = False
+    ) -> None:
+        self._set_operation_busy(True)
+
+        def failed(message: str) -> None:
+            self._set_operation_busy(False)
+            self._append_log(message)
+            title = "Маршрут восстановлен" if switch else "Ошибка подключения"
+            icon = QMessageBox.Icon.Warning if switch else QMessageBox.Icon.Critical
+            box = QMessageBox(icon, title, message, parent=self)
+            box.exec()
+            self._on_snapshot(self._controller.snapshot)
+
+        def succeeded(result: object) -> None:
+            self._set_operation_busy(False)
+            if isinstance(result, ConnectionSnapshot):
+                if result.state == ConnectionState.CONNECTED:
+                    self._append_log(
+                        f"Подключено через {result.route.label if result.route else '?'}; "
+                        f"внешний IP: {result.external_ip or '?'}"
+                    )
+                elif result.state == ConnectionState.DISCONNECTED:
+                    self._append_log("Соединение отключено")
+            self._on_snapshot(self._controller.snapshot)
+
+        self._start_operation(operation, succeeded, failed)
+
+    def _start_operation(
+        self,
+        operation: Callable[[], object],
+        on_success: Callable[[object], None],
+        on_failure: Callable[[str], None],
+    ) -> None:
+        if self._operation is not None:
+            return
+        worker = OperationThread(operation, self)
+        self._operation = worker
+        worker.succeeded.connect(on_success)
+        worker.failed.connect(on_failure)
+        worker.finished.connect(self._operation_finished)
+        worker.start()
+
+    def _operation_finished(self) -> None:
+        self._operation = None
+
+    def _set_operation_busy(self, busy: bool) -> None:
+        self.add_server_button.setEnabled(not busy)
+        self.server_combo.setEnabled(not busy)
+        self.mode_combo.setEnabled(not busy)
+        self.refresh_button.setEnabled(not busy and self._selected_server() is not None)
+
+    @Slot(object)
+    def _on_snapshot(self, snapshot: ConnectionSnapshot) -> None:
+        label = _STATE_LABELS[snapshot.state]
+        self.status_label.setText(label)
+        self.ip_label.setText(
+            f"Внешний IP: {snapshot.external_ip}" if snapshot.external_ip else ""
+        )
+        connected = snapshot.state == ConnectionState.CONNECTED
+        busy = snapshot.state in _BUSY_STATES
+        self.connect_button.setText("Отключить" if connected else "Подключить")
+        self.connect_button.setEnabled(
+            not busy and (connected or self._selected_route() is not None)
+        )
+        self.switch_button.setEnabled(
+            connected and self._selected_route() is not None and not busy
+        )
+        self.tray_toggle_action.setText("Отключить" if connected else "Подключить")
+        self.tray_toggle_action.setEnabled(not busy)
+        self.tray.setToolTip(f"Xrayebator — {label.lower()}")
+        if snapshot.error and snapshot.state == ConnectionState.ERROR:
+            self.status_label.setToolTip(snapshot.error)
+        else:
+            self.status_label.setToolTip("")
+
+    @Slot(QSystemTrayIcon.ActivationReason)
+    def _tray_activated(self, reason: QSystemTrayIcon.ActivationReason) -> None:
+        if reason in {
+            QSystemTrayIcon.ActivationReason.Trigger,
+            QSystemTrayIcon.ActivationReason.DoubleClick,
+        }:
+            self._show_window()
+
+    def _show_window(self) -> None:
+        self.show()
+        self.raise_()
+        self.activateWindow()
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        if self._quitting:
+            event.accept()
+            return
+        event.ignore()
+        self.hide()
+        self.tray.showMessage(
+            "Xrayebator",
+            "Приложение продолжает работать в системном трее.",
+            QSystemTrayIcon.MessageIcon.Information,
+            2500,
+        )
+
+    def _quit(self) -> None:
+        self._quitting = True
+        if self._controller.snapshot.state != ConnectionState.DISCONNECTED:
+            try:
+                self._controller.disconnect()
+            except Exception as exc:  # cleanup error is shown but quit remains possible
+                QMessageBox.warning(self, "Ошибка отключения", str(exc))
+        self.tray.hide()
+        from PySide6.QtWidgets import QApplication
+
+        application = QApplication.instance()
+        if application is not None:
+            application.quit()

--- a/gui/xrayebator_gui/ui/main_window.py
+++ b/gui/xrayebator_gui/ui/main_window.py
@@ -30,6 +30,7 @@ from ..core.connection import (
 from ..core.deploy import STEPS, make_deploy_thread
 from ..core.desktop_backend import DesktopBackend
 from ..core.helper_install import install_linux_helper
+from ..core.latency import probe_routes
 from ..core.routing import RoutingProfile
 from ..core.servers import ServerStore
 from ..core.ssh import SSHClient
@@ -113,6 +114,7 @@ class MainWindow(QMainWindow):
         self._bridge.snapshot_changed.connect(self._on_snapshot)
 
         self._routes: list[VlessLink] = []
+        self._latencies: dict[str, Optional[int]] = {}
         self._operation: Optional[OperationThread] = None
         self._deploy_thread: Optional[QThread] = None
         self._quitting = False
@@ -289,6 +291,7 @@ class MainWindow(QMainWindow):
     @Slot()
     def _server_changed(self) -> None:
         self._routes = []
+        self._latencies = {}
         self.route_combo.clear()
         server = self._selected_server()
         enabled = server is not None
@@ -315,23 +318,37 @@ class MainWindow(QMainWindow):
         self.route_combo.addItem("Загрузка подписки…")
         self._set_operation_busy(True)
 
-        def load() -> list[VlessLink]:
+        should_probe = self._controller.snapshot.state != ConnectionState.CONNECTED
+
+        def load() -> tuple[list[VlessLink], dict[str, Optional[int]]]:
             routes = subscription.parse(subscription.fetch(url))
             if not routes:
                 raise RuntimeError(
                     "Подписка не содержит поддерживаемых VLESS-маршрутов"
                 )
-            return routes
+            latencies = probe_routes(routes) if should_probe else {}
+            return routes, latencies
 
         self._start_operation(load, self._routes_loaded, self._routes_failed)
 
     def _routes_loaded(self, result: object) -> None:
-        routes = list(result) if isinstance(result, list) else []
+        if not isinstance(result, tuple) or len(result) != 2:
+            routes, latencies = [], {}
+        else:
+            routes = list(result[0])
+            latencies = dict(result[1])
         self._routes = routes
+        self._latencies = latencies
         self.route_combo.clear()
         for route in routes:
             label = route.remark or route.label
-            self.route_combo.addItem(f"{label} — {route.label}")
+            latency_ms = latencies.get(route.raw)
+            latency_label = (
+                f" · {latency_ms} ms"
+                if latency_ms is not None
+                else (" · timeout" if route.raw in latencies else "")
+            )
+            self.route_combo.addItem(f"{label} — {route.label}{latency_label}")
         default = subscription.pick_default(routes)
         if default is not None:
             self.route_combo.setCurrentIndex(routes.index(default))
@@ -342,6 +359,7 @@ class MainWindow(QMainWindow):
 
     def _routes_failed(self, message: str) -> None:
         self._routes = []
+        self._latencies = {}
         self.route_combo.clear()
         self.route_combo.addItem("Не удалось загрузить маршруты")
         self._append_log(f"Ошибка подписки: {message}")


### PR DESCRIPTION
## Что изменено

- добавлен Qt/PySide6 desktop-клиент для one-click VPS deployment, подписок, маршрутов, профилей и tray-управления;
- реализован Linux TUN helper с fail-closed маршрутизацией, DNS guard и проверяемым переключением;
- добавлена нативная CI-упаковка Windows x64, macOS Intel и macOS Apple Silicon;
- Xray-core закреплён на версии `v26.7.28`, его release archive проверяется по upstream `.dgst` до включения в bundle;
- `gui-v*` tags публикуют бинарники и `.sha256` как GitHub prerelease assets.

## Почему Releases, а не Packages

Это готовые пользовательские `.exe`/`.dmg`, поэтому workflow публикует их в GitHub Releases. GitHub Packages для этого проекта не требуется.

## Preview release

[`gui-v0.2.0-preview.1`](https://github.com/howdeploy/Xrayebator/releases/tag/gui-v0.2.0-preview.1) опубликован с Windows x64, macOS Intel и macOS Apple Silicon файлами и SHA-256 sidecars.

## Текущая граница preview

System proxy работает на Windows/macOS/Linux. Нативный TUN helper сейчас реализован и live-проверен только для Linux; Windows service и macOS launch daemon, а также code signing/notarization, остаются до stable release. GUI на Windows/macOS показывает это явно и не предлагает Linux installer.

## Проверки

- `ruff check`: passed
- `pytest`: 65 passed, 2 skipped
- wheel build: passed
- Windows x64 packaged executable smoke-test: passed
- macOS Intel packaged app smoke-test: passed
- macOS Apple Silicon packaged app smoke-test: passed
- pinned Xray download + upstream SHA-256 verification: passed on every target
- release assets + `.sha256` publication: passed
