### PR TITLE
fix(sni): синхронизация профилей без routes и пересборка списка SNI по замеру 03.09.2026

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -695,16 +695,18 @@ if [[ $? -eq 0 ]] && [[ -s "${DATA_DIR}/sni_list.txt" ]]; then
 else
   echo -e "${YELLOW}⚠ Не удалось загрузить список SNI, создаю базовый...${NC}"
   cat > "${DATA_DIR}/sni_list.txt" << 'EOF'
-www.ozon.ru|ru_whitelist|1
-wildberries.ru|ru_whitelist|1
-sberbank.ru|ru_whitelist|1
-nspk.ru|ru_whitelist|1
+# Аварийный список: не удалось скачать sni_list.txt из репозитория.
+# Порядок по замеру 03.09.2026 (MegaFon, Москва) — перепроверьте: probe test.
+api-maps.yandex.ru|yandex_cdn|1
+yandex.ru|yandex_cdn|1
+www.samsung.com|foreign|1
+dl.google.com|foreign|1
+swcdn.apple.com|foreign|1
+gateway.icloud.com|foreign|1
+www.cloudflare.com|foreign|1
+www.lovelive-anime.jp|foreign|1
 speller.yandex.net|yandex_cdn|2
-gosuslugi.ru|ru_whitelist|1
-stats.vk-portal.net|ru_whitelist|1
-github.com|foreign|3
-cloudflare.com|foreign|3
-www.microsoft.com|foreign|3
+www.gosuslugi.ru|ru_whitelist|2
 EOF
 fi
 

--- a/sni_list.txt
+++ b/sni_list.txt
@@ -1,95 +1,134 @@
 # XRAYEBATOR - Категоризированный список SNI
-# Последнее обновление: май 2026
+# Последнее обновление: 03.09.2026
 # Формат: домен|категория|приоритет
 # Категории: ru_whitelist, yandex_cdn, foreign, fallback
+#
+# ═══════════════════════════════════════════════════════════
+# ⚠ ЧЕМ ПОДТВЕРЖДЁН ПОРЯДОК И ПОЧЕМУ ЕГО НАДО ПЕРЕПРОВЕРЯТЬ
+# ═══════════════════════════════════════════════════════════
+# Замер: 03.09.2026, MegaFon (Москва), TLS-рукопожатие к 85.215.189.108.
+# ТСПУ фильтрует по SNI, и набор режущихся имён РАЗЛИЧАЕТСЯ ПО ОПЕРАТОРУ,
+# РЕГИОНУ И ДНЮ. Этот порядок верен для одной сети в один день — перед
+# применением перепроверьте сами: `xrayebator` → probe test, либо вручную
+#   openssl s_client -connect <ваш_ip>:443 -servername <домен> -tls1_3
+#
+# Прошлая версия списка ставила крупный РФ e-commerce и банки в приоритет 1
+# с пометкой «РКН их не блокирует — использовать в первую очередь». Замер
+# показал ОБРАТНОЕ: маскировка под них самая палевная, рукопожатие не проходит.
+#   Не прошли: www.ozon.ru, www.wildberries.ru, www.tinkoff.ru, cdn.jsdelivr.net
+#   Прошли:    www.cloudflare.com, api-maps.yandex.ru, www.microsoft.com,
+#              www.samsung.com, swcdn.apple.com, dl.google.com,
+#              gateway.icloud.com, yandex.ru, www.lovelive-anime.jp
+#
+# Отдельно про www.microsoft.com: рукопожатие проходит, но по долям трафика
+# на MegaFon домен деградировал — 11 соединений против 236 у www.samsung.com
+# при сопоставимом общем объёме, то есть маскировка слабая. Понижен до 3.
+#
+# НЕ годятся как Reality dest (SNI здесь используется и как dest <домен>:443):
+#   mail.ru          — отдаёт только TLS 1.2, Reality требует TLS 1.3
+#   cdn-telegram.org — не резолвится
+#
+# Первая незакомментированная строка файла = SNI по умолчанию для новых
+# профилей (_default_sni_for_transport), первые 20 строк = меню выбора SNI.
 
 # ═══════════════════════════════════════════════════════════
-# БЕЛЫЙ СПИСОК РФ - Критичные сервисы (РКН их не блокирует)
-# Использовать В ПЕРВУЮ ОЧЕРЕДЬ — максимальный шанс обхода
+# ПРИОРИТЕТ 1 — прошли замер 03.09.2026 (MegaFon, Москва)
+# Использовать В ПЕРВУЮ ОЧЕРЕДЬ
 # ═══════════════════════════════════════════════════════════
 
-# E-commerce (никогда не блокируется)
-www.ozon.ru|ru_whitelist|1
-api.ozon.ru|ru_whitelist|1
-st.ozon.ru|ru_whitelist|1
-ir.ozon.ru|ru_whitelist|1
-
-www.wildberries.ru|ru_whitelist|1
-splitter.wb.ru|ru_whitelist|1
-
-# Финансы (опорная инфраструктура)
-www.sberbank.ru|ru_whitelist|1
-www.tinkoff.ru|ru_whitelist|1
-www.alfabank.ru|ru_whitelist|1
-www.nspk.ru|ru_whitelist|1
-sbp.nspk.ru|ru_whitelist|1
-online.uralsib.ru|ru_whitelist|1
-online.vtb.ru|ru_whitelist|1
-
-# Логистика / госструктуры / маркетплейсы (приоритет 1)
-www.cdek.ru|ru_whitelist|1
-www.pochta.ru|ru_whitelist|1
-www.avito.ru|ru_whitelist|1
-
-# VK/Госмониторинг
-stats.vk-portal.net|ru_whitelist|1
-sun6-21.userapi.com|ru_whitelist|1
-sun6-20.userapi.com|ru_whitelist|1
-queuev4.vk.com|ru_whitelist|1
-eh.vk.com|ru_whitelist|1
-
-# Медиа/Развлечения
-www.kinopoisk.ru|ru_whitelist|1
-www.1tv.ru|ru_whitelist|1
-www.rbc.ru|ru_whitelist|1
-www.vedomosti.ru|ru_whitelist|1
-
-# Госуслуги/Порталы
-www.gosuslugi.ru|ru_whitelist|1
-www.mos.ru|ru_whitelist|1
-www.spb.gov.ru|ru_whitelist|1
+api-maps.yandex.ru|yandex_cdn|1
+yandex.ru|yandex_cdn|1
+www.samsung.com|foreign|1
+dl.google.com|foreign|1
+swcdn.apple.com|foreign|1
+gateway.icloud.com|foreign|1
+www.cloudflare.com|foreign|1
+www.lovelive-anime.jp|foreign|1
 
 # ═══════════════════════════════════════════════════════════
-# YANDEX CDN - Рандомные поддомены (очень рекомендуется)
-# Использовать ВТОРЫМ, если Tier-1 не работает
+# ПРИОРИТЕТ 2 — НЕ замерялись 03.09.2026, но и не из «палевного» класса
+# Яндекс-CDN, VK, госпорталы, медиа, логистика. Проверяйте probe test.
 # ═══════════════════════════════════════════════════════════
 
 speller.yandex.net|yandex_cdn|2
-api-maps.yandex.ru|yandex_cdn|2
 spell.yandex.net|yandex_cdn|2
 advapi.yandex.net|yandex_cdn|2
 mc.yandex.ru|yandex_cdn|2
 suggest.yandex.ru|yandex_cdn|2
 
+stats.vk-portal.net|ru_whitelist|2
+queuev4.vk.com|ru_whitelist|2
+eh.vk.com|ru_whitelist|2
+sun6-21.userapi.com|ru_whitelist|2
+sun6-20.userapi.com|ru_whitelist|2
+
+www.kinopoisk.ru|ru_whitelist|2
+www.1tv.ru|ru_whitelist|2
+www.rbc.ru|ru_whitelist|2
+www.vedomosti.ru|ru_whitelist|2
+
+www.gosuslugi.ru|ru_whitelist|2
+www.mos.ru|ru_whitelist|2
+www.spb.gov.ru|ru_whitelist|2
+
+www.cdek.ru|ru_whitelist|2
+www.pochta.ru|ru_whitelist|2
+
 # ═══════════════════════════════════════════════════════════
-# ИНОСТРАННЫЕ ДОМЕНЫ (не всегда проходят, в России могут фильтроваться)
-# Использовать ТРЕТЬИМ — резервное решение
+# ПРИОРИТЕТ 3 — иностранные, не замерялись, либо со слабой маскировкой
 # ═══════════════════════════════════════════════════════════
+
+# Рукопожатие проходит, но доля трафика на MegaFon мизерная (11 против 236
+# у www.samsung.com) — как маскировка работает плохо.
+www.microsoft.com|foreign|3
 
 www.github.com|foreign|3
 github.com|foreign|3
 raw.githubusercontent.com|foreign|3
 api.github.com|foreign|3
-www.cloudflare.com|foreign|3
 cdn.cloudflare.net|foreign|3
 aws.amazon.com|foreign|3
 
 # ═══════════════════════════════════════════════════════════
-# FALLBACK (экстренный случай, часто уходит под подозрение DPI)
-# Использовать ТОЛЬКО если ничего не сработало
+# ПРИОРИТЕТ 4 — НЕ ИСПОЛЬЗОВАТЬ без личной перепроверки
 # ═══════════════════════════════════════════════════════════
 
+# Замер 03.09.2026: TLS-рукопожатие с этим SNI НЕ проходит на MegaFon.
+# Оставлены в файле только чтобы probe test мог перепроверить их у вас.
+www.ozon.ru|fallback|4
+www.wildberries.ru|fallback|4
+www.tinkoff.ru|fallback|4
+
+# Не замерялись, но это тот же класс «крупный РФ e-commerce и банк»,
+# по которому замер отрицательный. Считать подозрительными.
+api.ozon.ru|ru_whitelist|4
+st.ozon.ru|ru_whitelist|4
+ir.ozon.ru|ru_whitelist|4
+splitter.wb.ru|ru_whitelist|4
+www.sberbank.ru|ru_whitelist|4
+www.alfabank.ru|ru_whitelist|4
+www.nspk.ru|ru_whitelist|4
+sbp.nspk.ru|ru_whitelist|4
+online.uralsib.ru|ru_whitelist|4
+online.vtb.ru|ru_whitelist|4
+www.avito.ru|ru_whitelist|4
+
+# Прежний fallback: под подозрение DPI уходят быстро.
 www.mozilla.org|fallback|4
 www.ubuntu.com|fallback|4
 www.debian.org|fallback|4
 
 # ═══════════════════════════════════════════════════════════
 # ПРИМЕЧАНИЯ:
-# 1. Всегда чередуйте домены из первого уровня — не используйте один надолго
-# 2. Yandex CDN-поддомены желательно обновлять раз в месяц
-# 3. Категории: ru_whitelist — РФ, yandex_cdn — Яндекс CDN, foreign — зарубежные домены, fallback — крайний случай
-# 4. Проверяйте SNI в вашем регионе — иногда Tier-1 могут временно не работать
-# 5. Никогда НЕ используйте национальный DNS РФ (166.70.x.x) для критичного обхода
-# 6. Используйте режим DNS — Auto (DoH → TCP) для наилучшей устойчивости (см. инструкции в документации)
+# 1. SNI здесь работает и как Reality dest (<домен>:443) — домен обязан
+#    отвечать по TLS 1.3 с HTTP/2 и резолвиться с самого VPS.
+# 2. Чередуйте домены приоритета 1 — не сидите на одном месяцами.
+# 3. Категории: ru_whitelist — РФ, yandex_cdn — Яндекс, foreign — зарубежные,
+#    fallback — крайний случай / провалившие замер.
+# 4. Приоритет — это ранг по свежему замеру, а не гарантия. Свой оператор
+#    проверяйте сами: фильтрация у MTS/Билайн/Ростелеком отличается.
+# 5. Никогда НЕ используйте национальный DNS РФ для критичного обхода.
+# 6. Режим DNS — Auto (DoH → TCP) даёт наилучшую устойчивость.
 #
-# Обновляйте список! РКН реагирует на популярные SNI — актуальность максимум месяц
+# Обновляйте список! ТСПУ реагирует на популярные SNI — актуальность
+# замера максимум месяц.

--- a/validation/test-legacy-profile-port-sync.sh
+++ b/validation/test-legacy-profile-port-sync.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Регрессия: update_all_profiles_on_port / update_all_profiles_port_reference
+# роняли jq на легаси-профиле без поля routes ("Invalid path expression with
+# result []"), safe_jq_write глушит stderr — профиль молча оставался со старым SNI.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+WORKDIR=$(mktemp -d /tmp/xrayebator-legacy-sync.XXXXXX)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/xrayebator"
+
+PROFILES_DIR="$WORKDIR/profiles"
+mkdir -p "$PROFILES_DIR"
+
+# Легаси-профиль: один маршрут, .port/.sni в корне, поля routes нет.
+cat > "$PROFILES_DIR/legacy.json" <<'JSON'
+{"name":"legacy","uuid":"11111111-1111-1111-1111-111111111111","transport":"tcp","port":443,"sni":"old.example"}
+JSON
+
+# Multi-route профиль: маршрут на 443 обновляется, маршрут на 8443 — нет.
+cat > "$PROFILES_DIR/multi.json" <<'JSON'
+{"name":"multi","uuid":"22222222-2222-2222-2222-222222222222","routes":[{"label":"a","port":443,"sni":"old.example"},{"label":"b","port":8443,"sni":"untouched.example"}]}
+JSON
+
+echo "Проверка синхронизации SNI по порту"
+update_all_profiles_on_port 443 "sni" "new.example" >/dev/null ||
+  fail "update_all_profiles_on_port вернул ошибку"
+
+[[ "$(jq -r '.sni' "$PROFILES_DIR/legacy.json")" == "new.example" ]] ||
+  fail "легаси-профиль без routes не получил новый SNI"
+[[ "$(jq -r '.routes[0].sni' "$PROFILES_DIR/multi.json")" == "new.example" ]] ||
+  fail "маршрут на порту 443 не получил новый SNI"
+[[ "$(jq -r '.routes[1].sni' "$PROFILES_DIR/multi.json")" == "untouched.example" ]] ||
+  fail "маршрут на другом порту не должен был меняться"
+
+echo "Проверка переноса порта"
+update_all_profiles_port_reference 443 2053 >/dev/null ||
+  fail "update_all_profiles_port_reference вернул ошибку"
+
+[[ "$(jq -r '.port' "$PROFILES_DIR/legacy.json")" == "2053" ]] ||
+  fail "легаси-профиль без routes не получил новый порт"
+[[ "$(jq -r '.routes[0].port' "$PROFILES_DIR/multi.json")" == "2053" ]] ||
+  fail "маршрут на порту 443 не получил новый порт"
+[[ "$(jq -r '.routes[1].port' "$PROFILES_DIR/multi.json")" == "8443" ]] ||
+  fail "маршрут на другом порту не должен был меняться"
+
+echo "OK: легаси-профили без routes синхронизируются"

--- a/xrayebator
+++ b/xrayebator
@@ -1298,9 +1298,13 @@ update_all_profiles_on_port() {
 
   for pname in "${profiles[@]}"; do
     local pfile="$PROFILES_DIR/$pname.json"
+    # Левая часть |= обязана быть путевым выражением. `(.routes // []) |=` таковым не является:
+    # на профиле без поля routes (легаси, один маршрут в корне) jq падает с
+    # "Invalid path expression with result []", safe_jq_write глушит stderr — и SNI/поле
+    # не обновляется. Поэтому сначала проверяем has("routes") и присваиваем по чистому пути.
     if safe_jq_write --argjson port "$port" --arg f "$field" --arg v "$value" '
       if .port == $port then .[$f] = $v else . end |
-      (.routes // []) |= map(if .port == $port then .[$f] = $v else . end)
+      if has("routes") then .routes |= map(if .port == $port then .[$f] = $v else . end) else . end
     ' "$pfile"; then
       echo -e "${CYAN}  → Обновлен: ${YELLOW}$pname${NC}"
     else
@@ -1343,9 +1347,11 @@ update_all_profiles_port_reference() {
   local pname
   for pname in "${profiles[@]}"; do
     local pfile="$PROFILES_DIR/$pname.json"
+    # Тот же путевой баг, что и в update_all_profiles_on_port: без has("routes")
+    # легаси-профиль без поля routes роняет jq и остаётся со старым портом.
     if safe_jq_write --argjson old_port "$old_port" --argjson new_port "$new_port" '
       if .port == $old_port then .port = $new_port else . end |
-      (.routes // []) |= map(if .port == $old_port then .port = $new_port else . end)
+      if has("routes") then .routes |= map(if .port == $old_port then .port = $new_port else . end) else . end
     ' "$pfile"; then
       echo -e "${CYAN}  → Обновлен порт: ${YELLOW}$pname${NC}"
     else
@@ -2632,12 +2638,16 @@ _migrate_sni_list_2026() {
     known_defaults["$domain"]=1
   done
 
+  # Строки обязаны совпадать с shipped sni_list.txt байт-в-байт: иначе grep -Fxq
+  # ниже считает список устаревшим и гоняет переписывание файла с рестартом Xray
+  # на пустом месте. Приоритеты — по замеру 03.09.2026: логистика 2,
+  # крупный РФ e-commerce и банки 4 (их SNI режется ТСПУ).
   local -a to_add_p1=(
-    "online.uralsib.ru|ru_whitelist|1"
-    "online.vtb.ru|ru_whitelist|1"
-    "www.cdek.ru|ru_whitelist|1"
-    "www.pochta.ru|ru_whitelist|1"
-    "www.avito.ru|ru_whitelist|1"
+    "online.uralsib.ru|ru_whitelist|4"
+    "online.vtb.ru|ru_whitelist|4"
+    "www.cdek.ru|ru_whitelist|2"
+    "www.pochta.ru|ru_whitelist|2"
+    "www.avito.ru|ru_whitelist|4"
   )
   local -a to_add_p3=(
     "github.com|foreign|3"
@@ -3857,7 +3867,9 @@ _default_sni_for_transport() {
     *)
       local from_list
       from_list=$(grep -v '^#' "$SNI_LIST" 2>/dev/null | grep -v '^[[:space:]]*$' | head -n 1 | cut -d'|' -f1)
-      [[ -z "$from_list" ]] && from_list="www.ozon.ru"
+      # Замер 03.09.2026 (MegaFon): www.ozon.ru как SNI режется ТСПУ — в качестве
+      # аварийного дефолта берём домен, прошедший тот же замер.
+      [[ -z "$from_list" ]] && from_list="api-maps.yandex.ru"
       echo "$from_list"
       ;;
   esac
@@ -7748,14 +7760,23 @@ change_sni_menu() {
   fi
 
   declare -A sni_desc
-  sni_desc["www.ozon.ru"]="E-commerce, макс. устойчивость для мобильных"
+  # Прошли замер 03.09.2026 (MegaFon, Москва) — верх списка
+  sni_desc["api-maps.yandex.ru"]="Яндекс Карты API — прошёл замер 03.09.2026"
+  sni_desc["yandex.ru"]="Яндекс, портал — прошёл замер 03.09.2026"
+  sni_desc["www.samsung.com"]="Максимальная доля трафика на MegaFon (236 соединений)"
+  sni_desc["dl.google.com"]="Google CDN обновлений — прошёл замер 03.09.2026"
+  sni_desc["swcdn.apple.com"]="Apple CDN обновлений — прошёл замер 03.09.2026"
+  sni_desc["gateway.icloud.com"]="iCloud gateway — прошёл замер 03.09.2026"
+  sni_desc["www.lovelive-anime.jp"]="Нишевый JP-домен, ТСПУ его не знает"
+  sni_desc["www.microsoft.com"]="Проходит, но доля трафика мизерная (11 против 236)"
+  sni_desc["www.ozon.ru"]="Замер 03.09.2026: TLS не проходит, не использовать"
   sni_desc["api.ozon.ru"]="Ozon API, хорошо в паре с основным"
   sni_desc["st.ozon.ru"]="Ozon CDN статика"
   sni_desc["ir.ozon.ru"]="Ozon CDN изображения"
-  sni_desc["www.wildberries.ru"]="E-commerce, стабильно для Мегафон/Ростелеком"
+  sni_desc["www.wildberries.ru"]="Замер 03.09.2026: TLS не проходит, не использовать"
   sni_desc["splitter.wb.ru"]="Wildberries CDN"
   sni_desc["www.sberbank.ru"]="Банк, оптимально для региональных сетей"
-  sni_desc["www.tinkoff.ru"]="Банк, стабильный вариант"
+  sni_desc["www.tinkoff.ru"]="Замер 03.09.2026: TLS не проходит, не использовать"
   sni_desc["www.alfabank.ru"]="Банк, запасной вариант"
   sni_desc["www.nspk.ru"]="Нац. платёжная система, сложно блокировать"
   sni_desc["sbp.nspk.ru"]="СБП, идеально для МТС"
@@ -7765,11 +7786,10 @@ change_sni_menu() {
   sni_desc["www.gosuslugi.ru"]="Госуслуги, для сложных регионов"
   sni_desc["www.mos.ru"]="Портал Москвы"
   sni_desc["speller.yandex.net"]="Яндекс CDN, универсальный вариант"
-  sni_desc["api-maps.yandex.ru"]="Яндекс Карты API"
   sni_desc["mc.yandex.ru"]="Яндекс Метрика"
   sni_desc["suggest.yandex.ru"]="Яндекс подсказки"
   sni_desc["www.github.com"]="Только если российские не работают!"
-  sni_desc["www.cloudflare.com"]="Для корпоративных каналов"
+  sni_desc["www.cloudflare.com"]="Прошёл замер 03.09.2026, хорош для gRPC"
   sni_desc["aws.amazon.com"]="AWS CDN, запасной вариант для gRPC"
 
   echo -e "${YELLOW}ТОП-20 доменов для маскировки:${NC}\n"


### PR DESCRIPTION
## Что здесь

Три независимые правки вокруг SNI, одним коммитом.

---

### 1. Баг jq: смена SNI молча не доезжала до легаси-профилей

`update_all_profiles_on_port()` обновляла профили выражением:

```jq
(.routes // []) |= map(if .port == $port then .[$f] = $v else . end)
```

Левая часть `|=` обязана быть **путевым выражением**, а `(.routes // [])` им не является. На профиле, у которого поля `routes` нет вовсе (легаси: один маршрут, `.port`/`.sni` в корне), jq падает:

```
jq: error (at <stdin>:1): Invalid path expression with result []
```

`safe_jq_write` глушит stderr (`2>/dev/null`), так что причина не видна, файл не меняется, и профиль остаётся со **старым SNI**, пока inbound уже переехал на новый. Клиент после этого не подключается.

Заменено на:

```jq
if has("routes") then .routes |= map(if .port == $port then .[$f] = $v else . end) else . end
```

**Тот же паттерн нашёлся в `update_all_profiles_port_reference()`** — он ломал перенос порта на ровно тех же профилях. Починены оба места, иначе правка закрывает половину дырки.

Проверка, jq 1.7.1:

| выражение | объект с `routes` | объект без `routes` |
|---|---|---|
| старое | ok | `Invalid path expression with result []`, exit 5 |
| новое | ok | ok, exit 0 |

Регрессия закреплена: `validation/test-legacy-profile-port-sync.sh` — на непатченном `main` падает (`✗ Ошибка jq — файл НЕ изменён`), с патчем проходит.

---

### 2. Жёстко зашитый SNI у `tcp-xudp` — уже исправлен в `main`

Литерал `"api-maps.yandex.ru"` в вызове `_append_route_json` для метки `tcp-xudp` в текущем `origin/main` **отсутствует**: коммит `d9a4462` переписал его на `$xudp_sni`, а пункт меню вызывает `create_profile` с пустым SNI, то есть тоже уходит в `_default_sni_for_transport`. Ничего изобретать не стал.

Для протокола, почему уместна именно `$xudp_sni`, а не соседки:

* `xudp_sni = _default_sni_for_transport "tcp-xudp"` — уважает self-steal домен (`_selfsteal_domain_value`), а без него отдаёт закреплённый за XUDP `api-maps.yandex.ru`;
* `default_sni` берётся для транспорта `tcp`, то есть первую строку `sni_list.txt` — сегодня она совпадает, но развалится при следующей перестановке списка;
* `grpc_sni` жёстко `www.cloudflare.com` ради стабильного HTTP/2 — к XUDP отношения не имеет.

Зато живой остаток той же болезни в `main` нашёлся и починен: аварийный дефолт в `_default_sni_for_transport`

```bash
[[ -z "$from_list" ]] && from_list="www.ozon.ru"
```

срабатывает, когда `sni_list.txt` пуст или недоступен, и выдавал новым профилям **измеренно заблокированный** SNI. Теперь `api-maps.yandex.ru`.

---

### 3. `sni_list.txt`: список был не просто устаревшим, а вредным

Шапка утверждала «БЕЛЫЙ СПИСОК РФ — РКН их не блокирует, использовать В ПЕРВУЮ ОЧЕРЕДЬ» и ставила в приоритет 1 крупный РФ e-commerce и банки. Замер показал **обратное**: маскировка именно под них самая палевная.

**Замер 03.09.2026, MegaFon (Москва), TLS-рукопожатие к `тестовый VPS`:**

* **не проходят:** `www.ozon.ru`, `www.wildberries.ru`, `www.tinkoff.ru`, `cdn.jsdelivr.net`
* **проходят:** `www.cloudflare.com`, `api-maps.yandex.ru`, `www.microsoft.com`, `www.samsung.com`, `swcdn.apple.com`, `dl.google.com`, `gateway.icloud.com`, `yandex.ru`, `www.lovelive-anime.jp`
* `www.microsoft.com` рукопожатие проходит, но по долям трафика на MegaFon деградировал: **11 соединений против 236** у `www.samsung.com` при сопоставимом общем объёме → как маскировка почти бесполезен, оставлен в приоритете 3 с пометкой.
* как **dest** не годятся и потому не добавлены: `mail.ru` (только TLS 1.2, Reality требует 1.3) и `cdn-telegram.org` (не резолвится). Оба факта записаны в шапку файла.

Что сделано:

* **приоритет 1** — только прошедшие замер: `api-maps.yandex.ru`, `yandex.ru`, `www.samsung.com`, `dl.google.com`, `swcdn.apple.com`, `gateway.icloud.com`, `www.cloudflare.com`, `www.lovelive-anime.jp`;
* **приоритет 2** — не замерялись и не из «палевного» класса: Яндекс-CDN, VK, госпорталы, медиа, логистика;
* **приоритет 3** — иностранные без замера + деградировавший `www.microsoft.com`;
* **приоритет 4** — три провалившихся домена (перекатегоризованы в `fallback`), остальной крупный РФ e-commerce и банки того же класса, прежний fallback;
* в шапке — дата замера, оператор, IP и прямое предупреждение: **фильтрация различается по оператору, региону и дню, перед применением перепроверять** (`probe test` или `openssl s_client -servername`).

Формат `домен|категория|приоритет` и четыре категории сохранены, структура файла тоже. **Ни один домен не удалён**, добавлены только 7 имён из замера. Порядок здесь не косметика: первая незакомментированная строка — это SNI по умолчанию для новых профилей (`_default_sni_for_transport`), а первые 20 строк — меню выбора SNI.

---

### Сопутствующее — без него правка 3 неполна

* **`install.sh`** — аварийный embedded-список SNI (пишется, когда `curl` не смог скачать `sni_list.txt`) начинался с `www.ozon.ru`. Это вторая копия тех же вредных данных: починить только `sni_list.txt` значило оставить установку при сетевом сбое на заблокированном SNI. Заменён на верх нового списка.
* **`_migrate_sni_list_2026`** — сверяет строки с shipped-файлом через `grep -Fxq` по **полной строке**. После смены приоритетов совпадение бы пропало, и миграция на каждом сервере без маркера впустую переписывала бы файл и дёргала `safe_restart_xray`. Приоритеты в массиве приведены к новому файлу; проверено, что все 6 строк снова находятся. Заодно проверено, что `swcdn.apple.com` / `gateway.icloud.com` не попадают под удаление apple/icloud в этой миграции (условие требует членства в `KNOWN_DEFAULTS_v1`, где их нет).
* **`change_sni_menu`** — у трёх провалившихся замер доменов описания «макс. устойчивость для мобильных» и «стабильный вариант» стали прямой дезинформацией, заменены на факт замера; добавлены описания для доменов нового приоритета 1, иначе верх меню рендерился бы как «Дополнительный вариант». Убран дубль ключа `sni_desc["api-maps.yandex.ru"]`.

---

## Проверки

```
bash -n xrayebator install.sh update.sh uninstall.sh   → чисто (4/4)
```

`validation/test-*.sh` на macOS, bash 3.2.57:

| | baseline (чистый `origin/main`) | после правок |
|---|---|---|
| `test-bbr-removal-migration.sh` | FAIL(1) | FAIL(1) |
| `test-cascade-upstream-import.sh` | FAIL(1), `declare -A` | FAIL(1) |
| `test-main-menu-numbering.sh` | FAIL(127), `mapfile` | FAIL(127) |
| `test-legacy-profile-port-sync.sh` | — (новый) | **PASS** |
| остальные 13 | PASS | PASS |

Список падающих **совпадает** с baseline — это ограничения bash 3.2 на macOS (`declare -A`, `mapfile`), а не следствие правок. На Linux с bash 5 они не воспроизводятся.

Целостность `sni_list.txt`: строк не по формату — 0, потерянных доменов — 0, дубликатов — 0, всего 51 запись.

**Не проверено:** сами замеры ТСПУ не воспроизводились в этом PR — порядок доменов взят из полевых данных 03.09.2026 как есть. Прогона create/delete профиля на живом сервере тоже не было, только `bash -n` и validation-набор.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
